### PR TITLE
Fix time zone deprecation warnings

### DIFF
--- a/app/views/admin/bad_logins/index.html.haml
+++ b/app/views/admin/bad_logins/index.html.haml
@@ -17,5 +17,5 @@
               %td= login.email
               %td= login.encrypted_password
               %td= login.ip
-              %td= "#{login.created_at.to_s(:db)} (#{time_ago_in_words(login.created_at, include_seconds: true)})"
+              %td= "#{login.created_at.to_fs(:db)} (#{time_ago_in_words(login.created_at, include_seconds: true)})"
           = render "utils/pagination_links", pager: @bad_logins, columns: 4

--- a/app/views/admin/carts/_errors.html.haml
+++ b/app/views/admin/carts/_errors.html.haml
@@ -12,7 +12,7 @@
       %tbody
         - cart.payment_errors.each do |error|
           %tr
-            %td{rowspan: 2}= error.created_at.to_s(:db)
+            %td{rowspan: 2}= error.created_at.to_fs(:db)
             %td= error.message || "(no message)"
             %td= error.payment_name
             %td= error.confirmation_email

--- a/app/views/admin/carts/_refunds.html.haml
+++ b/app/views/admin/carts/_refunds.html.haml
@@ -17,5 +17,5 @@
             %td= euros(refund.amount)
             %td= t("shop.payment.#{refund.automatic ? 'refund' : 'revoke'}")
             %td= refund.user.player.name
-            %td= refund.created_at.to_s(:db)
+            %td= refund.created_at.to_fs(:db)
             %td= refund.error || "None"

--- a/app/views/admin/carts/_summary.html.haml
+++ b/app/views/admin/carts/_summary.html.haml
@@ -38,7 +38,7 @@
       - if cart.payment_completed.present?
         %tr
           %th Payment completed
-          %td= cart.payment_completed.to_s(:db)
+          %td= cart.payment_completed.to_fs(:db)
       = render "utils/timestamps", object: cart, dt_format: :db
     - if can?(:edit, Cart) && cart.revokable?
       = link_to cart.refund_type + "...", edit_admin_cart_path(cart), class: "btn btn-danger"

--- a/app/views/admin/downloads/show.html.haml
+++ b/app/views/admin/downloads/show.html.haml
@@ -33,7 +33,7 @@
       - unless @download.updated_at == @download.data_updated_at
         %tr
           %th= "File last updated"
-          %td= @download.data_updated_at.to_s(:nosec)
+          %td= @download.data_updated_at.to_fs(:nosec)
       = render "utils/timestamps", object: @download, ability: :create
     = render "utils/show_buttons", object: @download
 

--- a/app/views/admin/failures/index.html.haml
+++ b/app/views/admin/failures/index.html.haml
@@ -16,7 +16,7 @@
             %tr
               %td= link_to failure.name, [:admin, failure]
               %td= failure.snippet
-              %td{title: failure.created_at.to_s(:db)}= time_ago_in_words(failure.created_at, include_seconds: true)
+              %td{title: failure.created_at.to_fs(:db)}= time_ago_in_words(failure.created_at, include_seconds: true)
               %td.text-center
                 = link_to [:admin, failure], method: :delete, class: "btn btn-danger btn-xs" do
                   %span.glyphicon.glyphicon-remove

--- a/app/views/admin/failures/show.html.haml
+++ b/app/views/admin/failures/show.html.haml
@@ -3,7 +3,7 @@
 = render "utils/prev_next", prev_next: @prev_next
 
 %h1.text-center= @failure.name
-%p.text-center= @failure.created_at.to_s(:db)
+%p.text-center= @failure.created_at.to_fs(:db)
 %pre= @failure.details
 
 = render "utils/show_buttons", object: @failure, admin: "search", edit: false, confirm: false

--- a/app/views/admin/journal_entries/show.html.haml
+++ b/app/views/admin/journal_entries/show.html.haml
@@ -27,7 +27,7 @@
         %td= @entry.by
       %tr
         %th At
-        %td= @entry.created_at.to_s(:db)
+        %td= @entry.created_at.to_fs(:db)
       %tr
         %th IP
         %td= @entry.ip

--- a/app/views/admin/logins/index.html.haml
+++ b/app/views/admin/logins/index.html.haml
@@ -19,5 +19,5 @@
               %td= link_to login.user.email, [:admin, login.user]
               %td= login.ip
               %td{class: "text-center"}= ok_ko(!login.error)
-              %td{title: login.created_at.to_s(:db)}= link_to time_ago_in_words(login.created_at, include_seconds: true), [:admin, login]
+              %td{title: login.created_at.to_fs(:db)}= link_to time_ago_in_words(login.created_at, include_seconds: true), [:admin, login]
           = render "utils/pagination_links", pager: @logins, columns: 5

--- a/app/views/admin/logins/show.html.haml
+++ b/app/views/admin/logins/show.html.haml
@@ -11,7 +11,7 @@
         %td= link_to @login.user.email, [:admin, @login.user]
       %tr
         %th Time
-        %td= @login.created_at.to_s(:db)
+        %td= @login.created_at.to_fs(:db)
       %tr
         %th IP
         %td= @login.ip

--- a/app/views/admin/mail_events/index.html.haml
+++ b/app/views/admin/mail_events/index.html.haml
@@ -35,7 +35,7 @@
                 %td.text-center= event.send(atr)
               %td.text-center= event.total
               %td.text-center= event.pages
-              %td.text-center= event.updated_at.to_s(:nosec)
+              %td.text-center= event.updated_at.to_fs(:nosec)
           = render "utils/pagination_links", pager: @events, columns: 16
 
 %hr

--- a/app/views/admin/payment_errors/index.html.haml
+++ b/app/views/admin/payment_errors/index.html.haml
@@ -19,7 +19,7 @@
               %td= error.message
               %td= error.payment_name
               %td= error.confirmation_email
-              %td= error.created_at.to_s(:db)
+              %td= error.created_at.to_fs(:db)
             %tr
               %td{colspan: 4}= error.details
           = render "utils/pagination_links", pager: @errors, columns: 5

--- a/app/views/admin/refunds/index.html.haml
+++ b/app/views/admin/refunds/index.html.haml
@@ -22,6 +22,6 @@
               %td= euros(refund.amount)
               %td= t("shop.payment.#{refund.automatic ? 'refund' : 'revoke'}")
               %td= refund.user.player.name
-              %td= refund.created_at.to_s(:db)
+              %td= refund.created_at.to_fs(:db)
               %td= refund.error || "None"
           = render "utils/pagination_links", pager: @refunds, columns: 6

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -33,7 +33,7 @@
         %th Verified
         %td
           - if @user.verified?
-            %time{datetime: @user.verified_at.to_s(:html5)}= @user.verified_at.to_s(:nosec)
+            %time{datetime: @user.verified_at.to_fs(:html5)}= @user.verified_at.to_fs(:nosec)
           - else
             Unverified -
             = link_to 'Click to verify', verify_admin_user_path

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -68,7 +68,7 @@
         - if admin && @event.flyer_updated_at != @event.updated_at
           %tr
             %th= "File last updated"
-            %td= @event.flyer_updated_at.to_s(:nosec)
+            %td= @event.flyer_updated_at.to_fs(:nosec)
       %tr
         %th= t("category")
         %td= t("event.category.#{@event.category}")

--- a/app/views/help/overview.html.haml
+++ b/app/views/help/overview.html.haml
@@ -1318,21 +1318,21 @@
 - cmd = []
 - cmd << '%p This is a demo.'
 - cmd << '%ul'
-- cmd << '  %li= "The date is #{ Date.today.to_s(:db) }."'
+- cmd << '  %li= "The date is #{ Date.today.to_fs(:db) }."'
 - cmd << '  %li= "The number of players is #{ Player.count }."'
 %pre~ cmd.join("\n")
 %p Second, Erb:
 - cmd = []
 - cmd << '<p>This is a demo.</p>'
 - cmd << '<ul>'
-- cmd << '  <li>The date is <%= Date.today.to_s(:db)} %>.</li>'
+- cmd << '  <li>The date is <%= Date.today.to_fs(:db)} %>.</li>'
 - cmd << '  <li>The number of players is <%= Player.count %>."</li>'
 - cmd << '</ul>'
 %pre~ cmd.join("\n")
 %p Both examples produce the same output, namely:
 %p This is a demo.
 %ul
-  %li= "The date is #{Date.today.to_s(:db)}."
+  %li= "The date is #{Date.today.to_fs(:db)}."
   %li= "The number of players is #{Player.count}."
 
 = render "header", topic: "appendix.mailgun"

--- a/app/views/help/suspend_account.html.haml
+++ b/app/views/help/suspend_account.html.haml
@@ -9,6 +9,6 @@
   For each login email, click to display the details then click <em>Edit</em>, change the user's status from "OK" to
   something else and click <em>Save</em>. For example, if the account is to be suspended for a year, then for the status
   enter something like:
-%pre= "Suspended until #{Date.today.years_since(1).to_s(:db)}"
+%pre= "Suspended until #{Date.today.years_since(1).to_fs(:db)}"
 %p The user will then be unable to log in using any of their accounts because their status is not "OK".
 %p The webmaster should make a note to revert the account status back to "OK" once the period of suspension has ended.

--- a/app/views/icu_mailer/verify_new_user_email.text.erb
+++ b/app/views/icu_mailer/verify_new_user_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.player.first_name.split(/\s+/).first %>,
 
-You registered a new login account for ICU member <%= @user.player.name(id: true) %> at <%= @user.created_at.to_s(:nosec) %> UTC using <%= @user.email %> as the username.
+You registered a new login account for ICU member <%= @user.player.name(id: true) %> at <%= @user.created_at.to_fs(:nosec) %> UTC using <%= @user.email %> as the username.
 
 To complete the process, please verify this email address by clicking the following link: <%= verify_user_url(@user, vp: @user.verification_param) %>
 

--- a/app/views/images/show.html.haml
+++ b/app/views/images/show.html.haml
@@ -34,7 +34,7 @@
         - unless @image.updated_at == @image.data_updated_at
           %tr
             %th= "Image last updated"
-            %td= @image.data_updated_at.to_s(:nosec)
+            %td= @image.data_updated_at.to_fs(:nosec)
     = render "utils/editing_details", object: @image
     %hr
     = render "utils/show_buttons", object: @image

--- a/app/views/payments/_cart_summary.html.haml
+++ b/app/views/payments/_cart_summary.html.haml
@@ -13,7 +13,7 @@
         - if cart.payment_completed
           %li
             = "#{t("shop.payment.time")}:"
-            %strong= "#{cart.payment_completed.to_s(:nosec)} GMT"
+            %strong= "#{cart.payment_completed.to_fs(:nosec)} GMT"
         - if cart.confirmation_email
           %li
             = t("shop.payment.confirmation_sent.#{cart.confirmation_sent ? 'success' : 'failure'}") + ":"

--- a/app/views/utils/_datetime.html.haml
+++ b/app/views/utils/_datetime.html.haml
@@ -1,7 +1,7 @@
 - defined?(done_by)   || done_by   = nil
 - defined?(dt_format) || dt_format = :nosec
 
-%time{datetime: datetime.to_s(:html5)}= datetime.to_s(dt_format)
+%time{datetime: datetime.to_fs(:html5)}= datetime.to_fs(dt_format)
 - if done_by
   = t("by")
   = done_by

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,18 @@ RSpec.configure do |config|
   end
 end
 
-Selenium::WebDriver::Chrome::Service.driver_path = "/usr/bin/chromedriver"
+if File.file?("/usr/bin/chromedriver")
+  Selenium::WebDriver::Chrome::Service.driver_path = "/usr/bin/chromedriver"
+elsif File.file?("/opt/homebrew/bin/chromedriver")
+  # Support macintosh development
+  Selenium::WebDriver::Chrome::Service.driver_path = "/opt/homebrew/bin/chromedriver"
+else
+  raise %Q{
+  I can't find a chromedriver for the Selenium specs.
+  You need to install one. It should be in either /usr/bin or /opt/homebrew/bin.
+  }
+end
+
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.register_driver :selenium_chrome_headless do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new


### PR DESCRIPTION
I just searched all places in the haml files using ".to_s(\:" and replaced the call with .to_fs.

This removes the annoying DEPRECATION warnings emitted in the log files and when running the specs.