### PR TITLE
Fixed JournalEntry.pluck call to remove the default scope

### DIFF
--- a/app/helpers/journal_entries_helper.rb
+++ b/app/helpers/journal_entries_helper.rb
@@ -1,6 +1,10 @@
 module JournalEntriesHelper
   def journal_entry_type_menu(selected)
-    types = JournalEntry.pluck("DISTINCT journalable_type").sort.map{|t| [t, t]}
+    types = JournalEntry.unscoped
+                     .order(:journalable_type)
+                     .distinct
+                     .pluck(:journalable_type)
+                     .map { |t| [t, t] }
     types.unshift(["Any type", ""])
     options_for_select(types, selected)
   end


### PR DESCRIPTION
This was ordering by created_at. This was a column not plucked, so the database objected to the query.

There's an argument to be made that the sort should be done by the ruby code rather than the database, but I prefer to make one call to the database, and then operate on the returned journalable_types.