### PR TITLE
Support elliptical key crypto for capistrano

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ group :development do
   gem "capistrano-rails"
   gem 'capistrano-maintenance', '~> 1.2', require: false
   gem "wirble"
+  # The following 2 gems are needed to support ed25519 encrypted keys for capistrano installs.
+  gem "bcrypt_pbkdf"
+  gem "ed25519"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,9 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-arm64-darwin)
+    bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
     bigdecimal (3.1.3)
     builder (3.2.4)
     cancancan (3.4.0)
@@ -113,6 +116,7 @@ GEM
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    ed25519 (1.4.0)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -311,10 +315,12 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-24
   x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt_pbkdf
   bigdecimal (>= 2.5.5)
   cancancan
   capistrano
@@ -324,6 +330,7 @@ DEPENDENCIES
   capybara
   colored
   database_cleaner
+  ed25519
   factory_bot_rails
   faker
   haml-rails


### PR DESCRIPTION
My ssh keys use ed25519, and so I needed to add support for this type of cryptography to successfully do capistrano deploys.