### PR TITLE
Event organisers can update and delete their own events

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -36,8 +36,9 @@ class Ability
     end
 
     if user.calendar?
-      can [:create, :update], Event
-      can :destroy, Event, user_id: user.id
+      can :create, Event
+      # Event organisers can edit or delete their own events
+      can [:update, :destroy], Event, user_id: user.id
     end
 
     if user.membership?

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -2,7 +2,7 @@
 
 = render "utils/prev_next", prev_next: @prev_next
 
-- admin = can?(:create, Image)
+- admin = can?(:create, @event)
 
 %h1.text-center= @event.name
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -2,7 +2,7 @@
 
 = render "utils/prev_next", prev_next: @prev_next
 
-- admin = can?(:create, @event)
+- admin = can?(:update, @event)
 
 %h1.text-center= @event.name
 


### PR DESCRIPTION
The previous ability said that anyone with calendar role can update any event.

This fix also means that organisers can edit their event and hand over organising to some other user.