### PR TITLE
removed charge ids and cart ids if the user cannot access carts

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -60,7 +60,7 @@ class Admin::ItemsController < ApplicationController
 
   def csv_data
     generator = Admin::EntryListCsvGenerator.new
-    generator.generate_from_items(@items, params[:description])
+    generator.generate_from_items(@items, params[:description], can?(:show, Cart))
   end
 
   def txt_data

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,7 +24,7 @@ class EventsController < ApplicationController
     items = Item::Entry.joins(:fee_entry => :event).paid.where(section: params[:section]).where("fees.event_id = ?", event.id)
     generator = Admin::EntryListCsvGenerator.new
 
-    send_data generator.generate_from_items(items, event.name), filename: download_filename(event, params[:section], 'csv'), type: 'text/csv'
+    send_data generator.generate_from_items(items, event.name, can?(:show, Cart)), filename: download_filename(event, params[:section], 'csv'), type: 'text/csv'
   end
 
   private

--- a/app/models/admin/entry_list_csv_generator.rb
+++ b/app/models/admin/entry_list_csv_generator.rb
@@ -2,10 +2,15 @@ require 'csv'
 
 module Admin
   class EntryListCsvGenerator
-    def generate_from_items(items, description = nil)
+    def generate_from_items(items, description = nil, show_charge_id = false)
       CSV.generate do |csv|
         csv << ["Items for #{description} generated on #{Time.now}", '', '', '', '']
-        csv << %w(Date Charge# Description Player ICU# Rating Fee Status Section Email Cart# Cart-Email Notes)
+        headings = ["Date"]
+        if show_charge_id
+          headings.concat(%w(Charge# Cart#))
+        end
+        headings.concat(%w(Description Player ICU# Rating Fee Status Section Email Cart-Email Notes))
+        csv << headings
         items.each do |item|
           if item.player.present?
             name, id, rating, email = item.player.name, item.player.id, item.player.latest_rating, item.player.email
@@ -14,9 +19,14 @@ module Admin
           else
             name, id, rating, email = nil, nil, nil, ''
           end
-          latest_charge = item.cart.present? && item.cart.latest_charge.present? ? item.cart.latest_charge : "(was not stored pre-update)"
-          latest_charge = "N/A" unless item.cost > 0
-          csv << [item.created_at.strftime("%Y-%m-%d"), latest_charge, item.description, name, id, rating, item.cost, item.status, item.section, email, item.cart_id, item.email, *item.notes]
+          row = [item.created_at.strftime("%Y-%m-%d")]
+          if show_charge_id
+            latest_charge = item.cart.present? && item.cart.latest_charge.present? ? item.cart.latest_charge : "(was not stored pre-update)"
+            latest_charge = "N/A" unless !item.cost.nil? and item.cost > 0
+            row.concat([latest_charge, item.cart_id])
+          end
+          row.concat([item.description, name, id, rating, item.cost, item.status, item.section, email, item.email, *item.notes])
+          csv << row
         end
       end
     end


### PR DESCRIPTION
The code which generates a CSV file from items is available to both the treasurer and tournament organisers. This code removes the charge IDs and cart IDs from the CSV file if the user is an organiser, as this is information which should only be available to the treasurer.