### PR TITLE
Carts should only be marked as refunded if all items have been refunded

### DIFF
--- a/app/controllers/admin/carts_controller.rb
+++ b/app/controllers/admin/carts_controller.rb
@@ -26,7 +26,7 @@ class Admin::CartsController < ApplicationController
 
   def edit
     @cart = Cart.include_items_plus.find(params[:id])
-    redirect_to [:admin, @cart] unless @cart.revokable?
+    redirect_to [:admin, @cart] if @cart.all_items_refunded?
   end
 
   def update

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -108,7 +108,7 @@ class Cart < ApplicationRecord
               item.refund
           end
       end
-      self.status = self.total == refund.amount ? "refunded" : "part_refunded"
+      self.status = all_items_refunded? ? "refunded" : "part_refunded"
       self.total -= refund.amount
     end
     save!
@@ -118,6 +118,14 @@ class Cart < ApplicationRecord
     refund
   ensure
     refund.save
+  end
+
+  def all_items_refunded?
+    items.all? &:refunded?
+  end
+
+  def any_items_refunded?
+    items.any? &:refunded?
   end
 
   def self.search(params, path)

--- a/app/views/admin/carts/_summary.html.haml
+++ b/app/views/admin/carts/_summary.html.haml
@@ -43,5 +43,5 @@
           %th Payment completed
           %td= cart.payment_completed.to_fs(:db)
       = render "utils/timestamps", object: cart, dt_format: :db
-    - if can?(:edit, Cart) && cart.revokable?
+    - if can?(:edit, Cart) && (cart.revokable? || !cart.all_items_refunded?)
       = link_to cart.refund_type + "...", edit_admin_cart_path(cart), class: "btn btn-danger"

--- a/spec/features/pay_spec.rb
+++ b/spec/features/pay_spec.rb
@@ -347,6 +347,7 @@ describe "Pay", js: true do
     it "without email" do
       login("membership")
       visit cart_path
+      wait_a_second(0.2)
       click_link payment_received
 
       fill_in payer_first_name, with: player.first_name


### PR DESCRIPTION
Issue is https://github.com/irishchessunion/icu_www_app/issues/28

The problem is the way the status is set in the Cart.refund method. We should dynamically calculate the status based on the status of the items.

Maybe we will do that in a later PR.