### PR TITLE
Updated redcarpet gem to avoid warning about T_DATA allocator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "redis"
 # gem "therubyracer", platforms: :ruby # (no longer needed)
 gem "icu_name", "1.3.0"
 gem "icu_utils", "1.3.3"
-gem "redcarpet"
+gem "redcarpet", "3.6.1"
 gem "stripe"
 gem "mailgun-ruby", require: "mailgun"
 # gem "paperclip"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
-    redcarpet (3.5.1)
+    redcarpet (3.6.1)
     redis (5.0.5)
       redis-client (>= 0.9.0)
     redis-client (0.11.2)
@@ -353,7 +353,7 @@ DEPENDENCIES
   rails (= 7.0.4)
   rails-controller-testing
   rake
-  redcarpet
+  redcarpet (= 3.6.1)
   redis
   rspec-rails
   sass-rails


### PR DESCRIPTION
This PR removes the warnings emitted by the redcarpet gem, which is used to convert markdown to HTML.