### PR TITLE
13 allow multiple categories for news items articles and events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "mail", "2.7.1" # latest version of mail does not work with rails 7.0.4 at t
 
 gem 'bigdecimal', '>= 2.5.5' # To avoid BigDecimal.new error
 gem 'terrapin'
+gem 'flag_shih_tzu' # Used to implement bitfields in ActiveRecord models
 
 group :development do
   gem "capistrano" # For same reason as colorize comment above

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x64-mingw-ucrt)
     ffi (1.17.2-x86_64-linux-gnu)
+    flag_shih_tzu (0.3.23)
     globalid (1.0.0)
       activesupport (>= 5.0)
     haml (6.1.2)
@@ -342,6 +343,7 @@ DEPENDENCIES
   ed25519
   factory_bot_rails
   faker
+  flag_shih_tzu
   haml-rails
   icu_name (= 1.3.0)
   icu_utils (= 1.3.3)

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -8,6 +8,7 @@ class Admin::ArticlesController < ApplicationController
 
   def create
     @article = Article.new(article_params)
+    set_selected_categories
     @article.user_id = current_user.id
 
     if @article.save
@@ -21,6 +22,7 @@ class Admin::ArticlesController < ApplicationController
 
   def update
     normalize_newlines(:article, :text)
+    set_selected_categories
     if @article.update(article_params)
       @article.journal(:update, current_user, request.remote_ip)
       redirect_to @article, notice: "Article was successfully updated"
@@ -43,6 +45,14 @@ class Admin::ArticlesController < ApplicationController
   end
 
   def article_params
-    params[:article].permit(:access, :active, :author, :category, :markdown, :text, :title, :year)
+    params[:article].permit(:access, :active, :author, :markdown, :text, :title, :year)
+  end
+
+  def set_selected_categories
+    if params[:article][:selected_categories].present?
+      @article.selected_categories = params[:article][:selected_categories]
+      # We need to delete the selected_categories param to avoid warnings in the Article update method.
+      params[:article].delete(:selected_categories)
+    end
   end
 end

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -10,6 +10,7 @@ class Admin::NewsController < ApplicationController
     @news = News.new(news_params)
     @news.date = Date.today
     @news.user_id = current_user.id
+    set_selected_categories
 
     if @news.save
       @news.journal(:create, current_user, request.remote_ip)
@@ -22,6 +23,7 @@ class Admin::NewsController < ApplicationController
 
   def update
     normalize_newlines(:news, :summary)
+    set_selected_categories
     if @news.update(news_params(false))
       @news.journal(:update, current_user, request.remote_ip)
       redirect_to @news, notice: "News was successfully updated"
@@ -44,8 +46,16 @@ class Admin::NewsController < ApplicationController
   end
 
   def news_params(new_record=true)
-    atrs = [:active, :headline, :summary, :category]
+    atrs = [:active, :headline, :summary]
     atrs.push(:date) unless new_record
     params[:news].permit(*atrs)
+  end
+
+  def set_selected_categories
+    if params[:news][:selected_categories].present?
+      @news.selected_categories = params[:news][:selected_categories]
+      # We need to delete the selected_categories param to avoid warnings in the News update method.
+      params[:news].delete(:selected_categories)
+    end
   end
 end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,12 +1,12 @@
 module ArticlesHelper
-  def article_category_menu(selected, default="article.category.any")
-    cats = Article::CATEGORIES.map { |cat| [t("article.category.#{cat}"), cat] }
+  def category_menu(selected, default="article.category.any")
+    cats = CategoriesOwner::CATEGORIES.map { |cat| [t("article.category.#{cat}"), cat] }
     cats.unshift [t(default), ""] if default
     options_for_select(cats, selected)
   end
 
-  def article_categories_menu(selected)
-    cats = Article::CATEGORIES.map { |cat| [t("article.category.#{cat}"), cat] }
+  def categories_menu(selected)
+    cats = CategoriesOwner::CATEGORIES.map { |cat| [t("article.category.#{cat}"), cat] }
     options_for_select(cats, selected)
   end
 

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -5,6 +5,11 @@ module ArticlesHelper
     options_for_select(cats, selected)
   end
 
+  def article_categories_menu(selected)
+    cats = Article::CATEGORIES.map { |cat| [t("article.category.#{cat}"), cat] }
+    options_for_select(cats, selected)
+  end
+
   def article_user_menu(selected)
     players = Player.joins(users: :articles).order(:last_name, :first_name).select("DISTINCT players.*").all.map{ |p| [p.name(reversed: true), p.id] }
     players.unshift [t("user.any_editor"), ""]

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,9 +6,29 @@ class Article < ApplicationRecord
   include Pageable
   include Remarkable
 
-  journalize %w[access active author category text title year], "/article/%d"
+  include FlagShihTzu
 
   CATEGORIES = %w[bulletin tournament biography obituary coaching juniors beginners general for_parents primary secondary women]
+  # Used to convert from string to symbol, without creating extra symbols from user input
+  CATEGORY_HASH = Hash[CATEGORIES.map(&:to_s).zip(0...CATEGORIES.size)]
+
+  has_flags 1 => :bulletin,
+            2 => :tournament,
+            3 => :biography,
+            4 => :obituary,
+            5 => :coaching,
+            6 => :juniors,
+            7 => :beginners,
+            8 => :general,
+            9 => :for_parents,
+            10 => :primary,
+            11 => :secondary,
+            12 => :women,
+            :column => 'categories',
+            :flag_query_mode => :bit_operator
+
+  journalize %w[access active author categories text title year], "/article/%d"
+
 
   belongs_to :user
   has_many :episodes, dependent: :destroy
@@ -16,7 +36,6 @@ class Article < ApplicationRecord
 
   before_validation :normalize_attributes
 
-  validates :category, inclusion: { in: CATEGORIES }
   validates :text, presence: true
   validates :title, presence: true, on: :create, length: { maximum: 150 }
   validates :year, numericality: { integer_only: true, greater_than_or_equal_to: Global::MIN_YEAR }
@@ -26,7 +45,7 @@ class Article < ApplicationRecord
   scope :include_series, -> { includes(episodes: :series) }
   scope :ordered, -> { order(year: :desc, created_at: :desc) }
   scope :linked_to_game, -> { where("text like '%[GME:%' or title like '%[GME:%'") }
-  scope :beginners, -> { where(category: "beginners") }
+  # The category specific scopes are automatically created by has_flags.
 
   def self.search(params, path, user, opt={})
     matches = ordered.include_player
@@ -50,7 +69,7 @@ class Article < ApplicationRecord
     matches = accessibility_matches(user, params[:access], matches)
     matches = matches.where(active: true) if params[:active] == "true"
     matches = matches.where(active: false) if params[:active] == "false"
-    matches = matches.where(category: params[:category]) if CATEGORIES.include?(params[:category])
+    matches = matches.where(sql_condition_for_flag(params[:category].to_sym, "categories")) if CATEGORIES.include?(params[:category])
     paginate(matches, params, path, opt)
   end
 
@@ -78,6 +97,33 @@ class Article < ApplicationRecord
     [text.scan(re), title.scan(re)].flatten
   end
 
+  # @param categories An array of strings containing potentially correct Article categories
+  # @return An array of legitimate symbols
+  def self.valid_categories(categories)
+    valid = []
+    categories.each do |category|
+      index = Article::CATEGORY_HASH[category]
+      if index
+        valid << CATEGORIES[index]
+      end
+    end
+    valid
+  end
+
+  # The FlagShihTzu class adds a method selected_categories= that only handles arrays of symbols.
+  alias assign_selected_categories selected_categories=
+
+  # Sets the categories bitset by convertign the array of strings to the appropriate set of bits.
+  # Accepts an array of strings which should all be the string equivalent of the legal categories.
+  # Any invalid strings will be ignored.
+  def selected_categories=(categories)
+    assign_selected_categories(Article.valid_categories(categories))
+  end
+
+  # A temporary helper method before we remove category altogether
+  def category
+    selected_categories.first || :any
+  end
   private
 
   def normalize_attributes

--- a/app/models/categories_owner.rb
+++ b/app/models/categories_owner.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Included by anything that supports multiple categories using a bitfield.
+module CategoriesOwner
+  def self.included(clazz)
+    clazz.include FlagShihTzu
+
+    clazz.has_flags 1 => :bulletin,
+              2 => :tournament,
+              3 => :biography,
+              4 => :obituary,
+              5 => :coaching,
+              6 => :juniors,
+              7 => :beginners,
+              8 => :general,
+              9 => :for_parents,
+              10 => :primary,
+              11 => :secondary,
+              12 => :women,
+              :column => 'categories',
+              :flag_query_mode => :bit_operator,
+              :check_for_column => false # Otherwise the migration fails as the Article class gets created before the migration happens.
+
+    # The FlagShihTzu class adds a method selected_categories= that only handles arrays of symbols.
+    clazz.alias_method :assign_selected_categories, :selected_categories=
+
+    def clazz.bitset_for_categories(categories)
+      bitset = 0
+      categories.each do |category|
+        bitset |= flag_mapping["categories"][category]
+      end
+      bitset
+    end
+
+  end
+
+  CATEGORIES = %w[bulletin tournament biography obituary coaching juniors beginners general for_parents primary secondary women]
+  # Used to convert from string to symbol, without creating extra symbols from user input
+  CATEGORY_HASH = Hash[CATEGORIES.map(&:to_s).zip(0...CATEGORIES.size)]
+
+  # @param categories An array of strings containing potentially correct Article categories
+  # @return An array of legitimate symbols
+  def CategoriesOwner.valid_categories(categories)
+    valid = []
+    categories.each do |category|
+      index = Article::CATEGORY_HASH[category]
+      if index
+        valid << CATEGORIES[index]
+      end
+    end
+    valid
+  end
+
+  # Sets the categories bitset by converting the array of strings to the appropriate set of bits.
+  # Accepts an array of strings which should all be the string equivalent of the legal categories.
+  # Any invalid strings will be ignored.
+  def selected_categories=(categories)
+    assign_selected_categories(CategoriesOwner.valid_categories(categories))
+  end
+
+  # A temporary helper method before we remove category altogether
+  def category
+    selected_categories.first || :any
+  end
+end

--- a/app/views/admin/article_ids/_search_form.html.haml
+++ b/app/views/admin/article_ids/_search_form.html.haml
@@ -4,7 +4,7 @@
     .col-sm-12
       = render "utils/text_field_tag", locals.merge(param: :title, text: t("article.title"), width: 6)
       = render "utils/text_field_tag", locals.merge(param: :author, text: t("article.author"), width: 5)
-      = render "utils/select_tag", locals.merge(param: :category, text: t("category"), menu: article_category_menu(params[:category]))
+      = render "utils/select_tag", locals.merge(param: :category, text: t("category"), menu: category_menu(params[:category]))
       - menu = access_menu(params[:access], Article.accessibilities_for(current_user), "access.any")
       = render "utils/select_tag", locals.merge(param: :access, text: t("access.access"), menu: menu)
 

--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -6,7 +6,7 @@
         = render "utils/form_header", object: @article, atr: :title
         - locals = { form: f, object: @article, col: "sm", pad: 2, mark: "required" }
         = render "utils/text_field_for", locals.merge(param: :title, text: t("article.title"), width: 7)
-        = render "utils/select_for", locals.merge(param: :category, text: t("category"), menu: article_category_menu(@article.category, "please_select"), width: 3)
+        = render "utils/select_for", locals.merge(param: :selected_categories, text: t("categories"), menu: article_categories_menu(@article.selected_categories), multiple: true, width: 4, size: 12)
         = render "utils/text_field_for", locals.merge(param: :year, text: t("year"), width: 2)
         = render "utils/text_field_for", locals.merge(param: :author, text: t("article.author"), width: 6, mark: "none")
         - menu = access_menu(@article.access, Article.accessibilities_for(current_user), @article.new_record? && "please_select")

--- a/app/views/admin/articles/_form.html.haml
+++ b/app/views/admin/articles/_form.html.haml
@@ -6,7 +6,7 @@
         = render "utils/form_header", object: @article, atr: :title
         - locals = { form: f, object: @article, col: "sm", pad: 2, mark: "required" }
         = render "utils/text_field_for", locals.merge(param: :title, text: t("article.title"), width: 7)
-        = render "utils/select_for", locals.merge(param: :selected_categories, text: t("categories"), menu: article_categories_menu(@article.selected_categories), multiple: true, width: 4, size: 12)
+        = render "utils/select_for", locals.merge(param: :selected_categories, text: t("categories"), menu: categories_menu(@article.selected_categories), multiple: true, width: 4, size: 12)
         = render "utils/text_field_for", locals.merge(param: :year, text: t("year"), width: 2)
         = render "utils/text_field_for", locals.merge(param: :author, text: t("article.author"), width: 6, mark: "none")
         - menu = access_menu(@article.access, Article.accessibilities_for(current_user), @article.new_record? && "please_select")

--- a/app/views/admin/news/_form.html.haml
+++ b/app/views/admin/news/_form.html.haml
@@ -8,7 +8,7 @@
         = render "utils/text_field_for", locals.merge(param: :headline, text: t("news.headline"), width: 7)
         - unless @news.new_record?
           = render "utils/text_field_for", locals.merge(param: :date, text: t("date"), width: 3)
-        = render "utils/select_for", locals.merge(param: :category, text: t("category"), menu: article_category_menu(@news.category, "please_select"), width: 3)
+        = render "utils/select_for", locals.merge(param: :selected_categories, text: t("categories"), menu: categories_menu(@news.selected_categories), multiple: true, width: 4, size: 12)
         = render "utils/check_box_for", locals.merge(param: :active, text: t("active"), width: 1, mark: "none")
         .form-group{class: @news.errors[:text].any? ? "has-error" : ""}
           .row

--- a/app/views/articles/_search_form.html.haml
+++ b/app/views/articles/_search_form.html.haml
@@ -2,7 +2,7 @@
   = render "utils/inline_text_field", param: :title, text: t("article.title"), size: 20
   = render "utils/inline_text_field", param: :year, text: t("year"), size: 10
   = render "utils/inline_text_field", param: :author, text: t("article.author"), size: 10
-  = render "utils/inline_select", param: :category, text: t("category"), menu: article_category_menu(params[:category])
+  = render "utils/inline_select", param: :category, text: t("category"), menu: category_menu(params[:category])
   - if current_user.guest?
     = hidden_field_tag :access, "all"
   - else

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -13,7 +13,7 @@
             %th= t("article.title")
             %th.col-sm-1= t("year")
             %th= t("article.author")
-            %th.col-sm-2= t("category")
+            %th.col-sm-2= t("categories")
             - if admin
               %th.col-sm-2= t("user.role.editor")
               %th.col-sm-1.text-center= t("active")
@@ -24,7 +24,7 @@
               %td= link_to article.title, article
               %td= article.year
               %td= article.author
-              %td= t("article.category.#{article.category}")
+              %td= article.selected_categories.map {|category| t("article.category.#{category}")}.join(", ")
               - if admin
                 %td= article.user.player.name
                 %td.text-center= ok_ko(article.active)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
   by: by
   beta: Beta quality software
   cancel: Cancel
+  categories: Categories
   category: Category
   city: City
   comment: Comment

--- a/db/migrate/20250805224904_add_categories_to_articles.rb
+++ b/db/migrate/20250805224904_add_categories_to_articles.rb
@@ -1,0 +1,14 @@
+class AddCategoriesToArticles < ActiveRecord::Migration[7.0]
+  def up
+    # flag_shih_tzu-managed bit field
+    add_column :articles, :categories, :integer, null: false, default: 0
+    Article::CATEGORIES.each do |category|
+      Article.where(category: category).update_all(Article.set_flag_sql(category.to_sym, true))
+    end
+    # I'd like to remove the category column, but I'll leave it be for the moment.
+  end
+
+  def down
+    remove_column :articles, :categories
+  end
+end

--- a/db/migrate/20250805224904_add_categories_to_articles.rb
+++ b/db/migrate/20250805224904_add_categories_to_articles.rb
@@ -2,7 +2,7 @@ class AddCategoriesToArticles < ActiveRecord::Migration[7.0]
   def up
     # flag_shih_tzu-managed bit field
     add_column :articles, :categories, :integer, null: false, default: 0
-    Article::CATEGORIES.each do |category|
+    CategoriesOwner::CATEGORIES.each do |category|
       Article.where(category: category).update_all(Article.set_flag_sql(category.to_sym, true))
     end
     # I'd like to remove the category column, but I'll leave it be for the moment.

--- a/db/migrate/20250814154246_add_categories_to_news.rb
+++ b/db/migrate/20250814154246_add_categories_to_news.rb
@@ -1,0 +1,14 @@
+class AddCategoriesToNews < ActiveRecord::Migration[7.0]
+  def up
+    # flag_shih_tzu-managed bit field
+    add_column :news, :categories, :integer, null: false, default: 0
+    CategoriesOwner::CATEGORIES.each do |category|
+      News.where(category: category).update_all(News.set_flag_sql(category.to_sym, true))
+    end
+    # I'd like to remove the category column, but I'll leave it be for the moment.
+  end
+
+  def down
+    remove_column :news, :categories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_01_184431) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "nlikes"
+    t.integer "categories", default: 0, null: false
     t.index ["access"], name: "index_articles_on_access"
     t.index ["active"], name: "index_articles_on_active"
     t.index ["author"], name: "index_articles_on_author"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -486,6 +486,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_01_184431) do
     t.datetime "updated_at", precision: nil
     t.integer "nlikes"
     t.string "category", limit: 20
+    t.integer "categories", default: 0, null: false
     t.index ["active"], name: "index_news_on_active"
     t.index ["date"], name: "index_news_on_date"
     t.index ["headline"], name: "index_news_on_headline"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :article do
     access   { "all" }
     active   { true }
-    category { "general" }
+    selected_categories { ["general"] }
     text     { Faker::Lorem.paragraphs.join("\n\n") }
     title    { Faker::Lorem.sentence(word_count: 4) }
     user

--- a/spec/features/admin/articles_spec.rb
+++ b/spec/features/admin/articles_spec.rb
@@ -7,7 +7,7 @@ describe Article do
   let(:author)     { I18n.t("article.author") }
   let(:text)       { I18n.t("article.text") }
   let(:title)      { I18n.t("article.title") }
-  let(:categories) { I18n.t("categories") }
+  let(:categories) { "article_selected_categories" }
 
   context "authorization" do
     let!(:article) { create(:article, user: user) }
@@ -141,6 +141,8 @@ describe Article do
       fill_in year, with: data.year
       fill_in author, with: data.author
       fill_in text, with: data.text
+      puts(data.inspect)
+      puts(data.category.inspect)
       select I18n.t("article.category.#{data.category}"), from: categories
       select I18n.t("access.#{data.access}"), from: access
       check active

--- a/spec/features/admin/articles_spec.rb
+++ b/spec/features/admin/articles_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 describe Article do
   include_context "features"
 
-  let(:access)   { I18n.t("access.access") }
-  let(:author)   { I18n.t("article.author") }
-  let(:text)     { I18n.t("article.text") }
-  let(:title)    { I18n.t("article.title") }
+  let(:access)     { I18n.t("access.access") }
+  let(:author)     { I18n.t("article.author") }
+  let(:text)       { I18n.t("article.text") }
+  let(:title)      { I18n.t("article.title") }
+  let(:categories) { I18n.t("categories") }
 
   context "authorization" do
     let!(:article) { create(:article, user: user) }
@@ -140,7 +141,7 @@ describe Article do
       fill_in year, with: data.year
       fill_in author, with: data.author
       fill_in text, with: data.text
-      select I18n.t("article.category.#{data.category}"), from: category
+      select I18n.t("article.category.#{data.category}"), from: categories
       select I18n.t("access.#{data.access}"), from: access
       check active
       click_button save
@@ -152,7 +153,7 @@ describe Article do
       expect(article.access).to eq data.access
       expect(article.active).to eq data.active
       expect(article.author).to eq data.author
-      expect(article.category).to eq data.category
+      expect(article.categories).to eq data.categories
       expect(article.text).to eq data.text
       expect(article.title).to eq data.title
       expect(article.year).to eq data.year
@@ -166,7 +167,7 @@ describe Article do
       fill_in year, with: data.year
       fill_in author, with: data.author
       fill_in text, with: data.text + "\n\nSee also [ART:99], [DLD:99].\n"
-      select I18n.t("article.category.#{data.category}"), from: category
+      select I18n.t("article.category.#{data.category}"), from: categories
       select I18n.t("access.#{data.access}"), from: access
       check active
       click_button save

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -71,7 +71,7 @@ describe Article do
 
   context "categories" do
     it "includes women" do
-      expect(Article::CATEGORIES.include?("women")).to be(true)
+      expect(CategoriesOwner::CATEGORIES.include?("women")).to be(true)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,7 +111,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
 
   # Some machines will run the specs correctly in non-headless mode.
   # But to avoid flashing screens, leave the following line uncommented.
-  #options.add_argument('--headless')
+  options.add_argument('--headless')
   options.add_argument('--window-size=1920,1080')
   options.add_argument('--no-sandbox')
   # options.add_argument('--disable-dev-shm-usage')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   #   # (e.g. via a command-line flag).
   #   config.default_formatter = 'doc'
   # end
+  config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
@@ -110,7 +111,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
 
   # Some machines will run the specs correctly in non-headless mode.
   # But to avoid flashing screens, leave the following line uncommented.
-  options.add_argument('--headless')
+  #options.add_argument('--headless')
   options.add_argument('--window-size=1920,1080')
   options.add_argument('--no-sandbox')
   # options.add_argument('--disable-dev-shm-usage')


### PR DESCRIPTION
Implemented multiple categories for articles.
Partially implements issue #13 
Still have to do news items.

See commit messages for more info.

I have created a module, CategoriesOwner, that can be included in any model that needs to implement multiple categories. It uses a FlagShiuTzu gem, which is more suited to a model that needs multiple named flags, rather than what we want, which is 0 or more selected categories for a News item or an Article.

I have deliberately left the category column in both news and articles tables, just until we are happy everything works.
The 2 migrations migrate the category column over to the bitset categories column. Going the down direction is never going to work, although we could just use the first category selected as an appropriate value.

I also renamed the articles_category_menu helper function to category_menu, as that is they are used in both the article form and the news form.