### PR TITLE
I changed the type of the note column in the events table to text, wh…

### DIFF
--- a/db/migrate/20250826134421_increase_length_of_events_note_field.rb
+++ b/db/migrate/20250826134421_increase_length_of_events_note_field.rb
@@ -10,8 +10,8 @@ class IncreaseLengthOfEventsNoteField < ActiveRecord::Migration[7.0]
     # Copy data, truncating if longer than 255 characters
     Event.find_each do |event|
       temp_note = event.note
-      if event.note && event.note.length > 255
-        temp_note = event.note[0, 254]
+      if event.note && event.note.length > 511
+        temp_note = event.note[0, 511]
       end
       event.update_column(:temp_note, temp_note)
     end

--- a/db/migrate/20250826134421_increase_length_of_events_note_field.rb
+++ b/db/migrate/20250826134421_increase_length_of_events_note_field.rb
@@ -1,0 +1,23 @@
+class IncreaseLengthOfEventsNoteField < ActiveRecord::Migration[7.0]
+  def up
+    change_column :events, :note, :text
+  end
+
+  def down
+    # Create a temporary column to hold the truncated values
+    add_column :events, :temp_note, :string
+
+    # Copy data, truncating if longer than 255 characters
+    Event.find_each do |event|
+      temp_note = event.note
+      if event.note && event.note.length > 255
+        temp_note = event.note[0, 254]
+      end
+      event.update_column(:temp_note, temp_note)
+    end
+
+    # Remove the original column and rename the temporary column
+    remove_column :events, :note
+    rename_column :events, :temp_note, :note
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_01_184431) do
     t.string "location", limit: 100
     t.decimal "long", precision: 10, scale: 7
     t.string "name", limit: 75
-    t.string "note", limit: 512
+    t.text "note"
     t.string "phone", limit: 25
     t.decimal "prize_fund", precision: 8, scale: 2
     t.string "source", limit: 8, default: "www2"


### PR DESCRIPTION
Fixes https://github.com/irishchessunion/icu_www_app/issues/48

I added a migration that switches column types. Migrating up is easy. Migrating down required reading every events record, and truncating long strings.