### PR TITLE
Added a short_event flag to the events table

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -3,7 +3,7 @@ class Admin::EventsController < ApplicationController
   authorize_resource
 
   def new
-    @event = Event.new
+    @event = Event.new(short_event: true)
   end
 
   def create
@@ -42,7 +42,7 @@ class Admin::EventsController < ApplicationController
   end
 
   def event_params
-    params[:event].permit(:flyer, :name, :category, :location, :start_date, :end_date, :contact, :phone, :email,
+    params[:event].permit(:flyer, :name, :short_event, :category, :location, :start_date, :end_date, :contact, :phone, :email,
                           :url, :pairings_url, :live_games_url, :live_games_url2, :streaming_url, :results_url, :report_url,
                           :lat, :long, :prize_fund, :active, :note, :sections, :user_id)
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,21 +3,20 @@ class PagesController < ApplicationController
 
   def home
     @news = News.active.nonjunior.ordered.limit(8)
-    @junior_events = Event.active.junior.where('end_date >= ?', Date.today).ordered.limit(3)
-    @irish_events = Event.active.where(category: %w(irish women)).where('end_date >= ?', Date.today).ordered.limit(4)
+    @irish_events = Event.active.short.where(category: %w(irish women)).where('end_date >= ?', Date.today).ordered.limit(4)
     @results = Result.recent
   end
 
   def home2
     @news = News.active.nonjunior.ordered.limit(8)
-    @irish_events = Event.active.where(category: %w(irish women)).where('end_date >= ?', Date.today).ordered.limit(4)
+    @irish_events = Event.active.short.where(category: %w(irish women)).where('end_date >= ?', Date.today).ordered.limit(4)
     @results = Result.recent
   end
 
   def juniors
     @news = News.active.junior.ordered.limit(8)
-    @junior_events = Event.active.junior.where('end_date >= ?', Date.today).ordered.limit(4)
-    @international_events = Event.active.junint.where('end_date >= ?', Date.today).ordered.limit(4)
+    @junior_events = Event.active.short.junior.where('end_date >= ?', Date.today).ordered.limit(4)
+    @international_events = Event.active.short.junint.where('end_date >= ?', Date.today).ordered.limit(4)
     @junior_clubs = Club.active.junior
   end
 
@@ -29,8 +28,8 @@ class PagesController < ApplicationController
 
   def women
     @news = News.active.women
-    @woman_events = Event.active.women.where('end_date >= ?', Date.today).ordered.limit(4)
-    @international_events = Event.active.wint.where('end_date >= ?', Date.today).ordered.limit(4)
+    @woman_events = Event.active.short.women.where('end_date >= ?', Date.today).ordered.limit(4)
+    @international_events = Event.active.short.wint.where('end_date >= ?', Date.today).ordered.limit(4)
     @officers = Officer.active.ordered.include_players
     @officer = @officers.find { |officer| officer.role == "women" }
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,6 +21,7 @@ class Event < ApplicationRecord
   CONTENT_TYPES = TYPES.values.flatten
 
   scope :active, -> { where(active: true) }
+  scope :short, -> { where(short_event: true) }
   scope :with_geocodes, -> { where.not(lat: nil).where.not(long: nil) }
   scope :upcoming, -> { active.where("start_date > ?", Date.today).order(:start_date) }
 

--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -9,6 +9,7 @@
         = render "utils/form_header", object: @event, atr: :name
         - locals = { form: f, object: @event, col: "md", pad: 3, mark: "required" }
         = render "utils/text_field_for", locals.merge(param: :name, text: t("event.name"), width: 5)
+        = render "utils/check_box_for",  locals.merge(param: :short_event, text: t("event.short_event"), width: 1)
         = render "utils/text_field_for", locals.merge(param: :location, text: t("event.location"), width: 6)
         = render "utils/text_field_for", locals.merge(param: :start_date, text: t("event.start"), width: 3, placeholder: t("date_format"))
         = render "utils/text_field_for", locals.merge(param: :end_date, text: t("event.end"), width: 3, placeholder: t("date_format"))

--- a/config/locales/events/en.yml
+++ b/config/locales/events/en.yml
@@ -15,6 +15,7 @@ en:
     long: Longitude
     map: Forthcoming Events Map
     name: Event name
+    short_event: Short Playing Event
     start: Start date
     pairings_url: Pairings URL
     phone: Contact phone

--- a/db/migrate/20251119171413_add_short_event_flag_to_events.rb
+++ b/db/migrate/20251119171413_add_short_event_flag_to_events.rb
@@ -1,0 +1,5 @@
+class AddShortEventFlagToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :short_event, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_08_01_184431) do
+ActiveRecord::Schema[7.0].define(version: 2025_11_19_171413) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -219,6 +219,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_01_184431) do
     t.string "report_url"
     t.string "streaming_url"
     t.string "live_games_url2"
+    t.boolean "short_event", default: true
     t.index ["active"], name: "index_events_on_active"
     t.index ["category"], name: "index_events_on_category"
     t.index ["end_date"], name: "index_events_on_end_date"


### PR DESCRIPTION
Added a short_event flag to populate the current events section on the home page.
By default it is true.

We may have to limit editing the flag to admins, but for now, we'll let the organiser modify it accordingly.

I also removed querying the junior events in the home page controller. It was unnecessary work.