### PR TITLE
Add category to metadata events index

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -105,6 +105,11 @@
   display: none;
 }
 
+.event-location-span .glyphicon {
+  font-size: 12px;
+  margin-right: 2px;
+}
+
 .panel.panel-default {
     margin-bottom: 0;
 }

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -49,7 +49,8 @@
                 -# Shows only when screen width <= 768px
                 %br.event-location-span
                 %span.event-location-span
-                  = link_to_if event.geocodes?, event.location, events_map_path(event)
+                  %span.glyphicon.glyphicon-map-marker
+                  =link_to_if event.geocodes?, event.location, events_map_path(event)
 
               -# Shows only when screen width > 768px
               %td.event-location-col= link_to_if event.geocodes?, event.location, events_map_path(event)


### PR DESCRIPTION
1. Added category to metadata shown under each event on the "Upcoming Events" page.
2. Updated styling to make metadata spans collapse to a column on mobile rather than being side to side
3. Updated styling so Location collapses on mobile to show under the Event name / metadata, otherwise it ends up off-screen necessitating the user to horizontal-scroll back and forth to view it.

<img width="536" height="227" alt="image" src="https://github.com/user-attachments/assets/f760d8c3-2cea-42b0-a5dc-47e49c3dd7fb" />
