### PR TITLE
Removed patron section from header.

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,9 +3,3 @@
     = image_tag "misc/logo.png", alt: t("icu.logo"), title: t("icu.logo"), size: "70x70", class: "visible-lg-block header-logo"
   .col-lg-8.text-center
     %h1= t("icu.ticu")
-    %h5
-      = succeed(":") do
-        = t("patron")
-      = succeed(",") do
-        = "Michael D. Higgins"
-      = t("president_irl")


### PR DESCRIPTION
Michael D. Higgins is no longer president of Ireland and as such has relinquished all his patronages due to his former position.