### PR TITLE
Add variables files for each bootswatch theme

### DIFF
--- a/app/assets/stylesheets/variables_cerulean.css
+++ b/app/assets/stylesheets/variables_cerulean.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/cerulean/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: color-mix(in oklab, var(--gray-base), white 33.5%);
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #2FA4E7;
+  --brand-success: #73A839;
+  --brand-info: #033C73;
+  --brand-warning: #DD5600;
+  --brand-danger: #C71C22;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_cosmo.css
+++ b/app/assets/stylesheets/variables_cosmo.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/cosmo/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: color-mix(in oklab, var(--gray-base), white 33.5%);
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #2780E3;
+  --brand-success: #3FB618;
+  --brand-info: #9954BB;
+  --brand-warning: #FF7518;
+  --brand-danger: #FF0039;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-dark);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_cyborg.css
+++ b/app/assets/stylesheets/variables_cyborg.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/cyborg/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: #222;
+  --gray-dark: #282828;
+  --gray: #555;
+  --gray-light: #888;
+  --gray-lighter: #ADAFAE;
+
+  --brand-primary: #2A9FD6;
+  --brand-success: #77B300;
+  --brand-info: #9933CC;
+  --brand-warning: #FF8800;
+  --brand-danger: #CC0000;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #060606;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-light);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_darkly.css
+++ b/app/assets/stylesheets/variables_darkly.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/darkly/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: #777;
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #375a7f;
+  --brand-success: #00bc8c;
+  --brand-info: #3498DB;
+  --brand-warning: #F39C12;
+  --brand-danger: #E74C3C;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: var(--gray-darker);
+
+  /* Global text color on `<body>`. */
+  --text-color: #FFF;
+
+  /* Global textual link color. */
+  --link-color: color-mix(in oklab, var(--brand-success), white 10%);
+}

--- a/app/assets/stylesheets/variables_flatly.css
+++ b/app/assets/stylesheets/variables_flatly.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/flatly/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: #222;
+  --gray-dark: #7b8a8b;
+  --gray: #95a5a6;
+  --gray-light: #b4bcc2;
+  --gray-lighter: #ecf0f1;
+
+  --brand-primary: #2C3E50;
+  --brand-success: #18BC9C;
+  --brand-info: #3498DB;
+  --brand-warning: #F39C12;
+  --brand-danger: #E74C3C;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #fff;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--brand-primary);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-success);
+}

--- a/app/assets/stylesheets/variables_journal.css
+++ b/app/assets/stylesheets/variables_journal.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/journal/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: #777;
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #EB6864;
+  --brand-success: #22B24C;
+  --brand-info: #369;
+  --brand-warning: #F5E625;
+  --brand-danger: #F57A00;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_lumen.css
+++ b/app/assets/stylesheets/variables_lumen.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/lumen/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: color-mix(in oklab, var(--gray-base), white 33.5%);
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #158CBA;
+  --brand-success: #28B62C;
+  --brand-info: #75CAEB;
+  --brand-warning: #FF851B;
+  --brand-danger: #FF4136;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_paper.css
+++ b/app/assets/stylesheets/variables_paper.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/paper/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: #212121;
+  --gray: #666;
+  --gray-light: #BBB;
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #2196F3;
+  --brand-success: #4CAF50;
+  --brand-info: #9C27B0;
+  --brand-warning: #ff9800;
+  --brand-danger: #e51c23;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_readable.css
+++ b/app/assets/stylesheets/variables_readable.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/readable/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: color-mix(in oklab, var(--gray-base), white 33.5%);
+  --gray-light: color-mix(in oklab, var(--gray-base), white 70%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #4582EC;
+  --brand-success: #3FAD46;
+  --brand-info: #5bc0de;
+  --brand-warning: #f0ad4e;
+  --brand-danger: #d9534f;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-dark);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_sandstone.css
+++ b/app/assets/stylesheets/variables_sandstone.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/sandstone/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: #3E3F3A;
+  --gray-dark: #8E8C84;
+  --gray: #98978B;
+  --gray-light: #DFD7CA;
+  --gray-lighter: #F8F5F0;
+
+  --brand-primary: #325D88;
+  --brand-success: #93C54B;
+  --brand-info: #29ABE0;
+  --brand-warning: #F47C3C;
+  --brand-danger: #d9534f;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: #3E3F3A;
+
+  /* Global textual link color. */
+  --link-color: var(--brand-success);
+}

--- a/app/assets/stylesheets/variables_simplex.css
+++ b/app/assets/stylesheets/variables_simplex.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/simplex/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: #444;
+  --gray: #777;
+  --gray-light: #808080;
+  --gray-lighter: #DDD;
+
+  --brand-primary: #D9230F;
+  --brand-success: #469408;
+  --brand-info: #029ACF;
+  --brand-warning: #9B479F;
+  --brand-danger: #D9831F;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FCFCFC;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_slate.css
+++ b/app/assets/stylesheets/variables_slate.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/slate/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: #272B30;
+  --gray-dark: #3A3F44;
+  --gray: #52575C;
+  --gray-light: #7A8288;
+  --gray-lighter: #999;
+
+  --brand-primary: var(--gray-light);
+  --brand-success: #62c462;
+  --brand-info: #5bc0de;
+  --brand-warning: #f89406;
+  --brand-danger: #ee5f5b;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: var(--gray-darker);
+
+  /* Global text color on `<body>`. */
+  --text-color: #C8C8C8;
+
+  /* Global textual link color. */
+  --link-color: #FFF;
+}

--- a/app/assets/stylesheets/variables_spacelab.css
+++ b/app/assets/stylesheets/variables_spacelab.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/spacelab/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: #2d2d2d;
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: #666;
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #446E9B;
+  --brand-success: #3CB521;
+  --brand-info: #3399F3;
+  --brand-warning: #D47500;
+  --brand-danger: #CD0200;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #FFF;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-info);
+}

--- a/app/assets/stylesheets/variables_superhero.css
+++ b/app/assets/stylesheets/variables_superhero.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/superhero/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: color-mix(in oklab, var(--gray-base), white 33.5%);
+  --gray-light: #4E5D6C;
+  --gray-lighter: #EBEBEB;
+
+  --brand-primary: #DF691A;
+  --brand-success: #5cb85c;
+  --brand-info: #5bc0de;
+  --brand-warning: #f0ad4e;
+  --brand-danger: #d9534f;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #2B3E50;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-lighter);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_united.css
+++ b/app/assets/stylesheets/variables_united.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/united/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: #333;
+  --gray: #777;
+  --gray-light: #AEA79F;
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #E95420;
+  --brand-success: #38B44A;
+  --brand-info: #772953;
+  --brand-warning: #EFB73E;
+  --brand-danger: #DF382C;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #fff;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-dark);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/assets/stylesheets/variables_yeti.css
+++ b/app/assets/stylesheets/variables_yeti.css
@@ -1,0 +1,27 @@
+:root {
+  /* https://bootswatch.com/3/yeti/variables.less */
+  /* Gray and brand colors for use across Bootstrap. */
+  --gray-base: #000;
+  --gray-darker: color-mix(in oklab, var(--gray-base), white 13.5%);
+  --gray-dark: color-mix(in oklab, var(--gray-base), white 20%);
+  --gray: #6f6f6f;
+  --gray-light: color-mix(in oklab, var(--gray-base), white 60%);
+  --gray-lighter: color-mix(in oklab, var(--gray-base), white 93.5%);
+
+  --brand-primary: #008cba;
+  --brand-success: #43ac6a;
+  --brand-info: #5bc0de;
+  --brand-warning: #E99002;
+  --brand-danger: #F04124;
+
+  /* Settings for some of the most global styles. */
+
+  /* Background color for `<body>`. */
+  --body-bg: #fff;
+
+  /* Global text color on `<body>`. */
+  --text-color: var(--gray-darker);
+
+  /* Global textual link color. */
+  --link-color: var(--brand-primary);
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,7 @@
     - if defined?(Capybara::Lockstep)
       = capybara_lockstep
     = stylesheet_link_tag "application", media: "all"
+    = stylesheet_link_tag "variables_#{current_user.preferred_theme.downcase}", media: "all"
     = stylesheet_link_tag "#{current_user.preferred_theme.downcase}.min", media: "all"
     = javascript_include_tag "application"
     - if content_for?(:includes)


### PR DESCRIPTION
Adds a variable file with main colour variables for each Bootswatch (v3) theme extracted from provided variables.less files.

This allows us to create custom elements while respecting the theme colours.

e.g. (_in application.css_)
`.card { background: var(--brand-info); }`

would populate with the correct brand-info colour for the user's selected theme.