### PR TITLE
Fix refunds search

### DIFF
--- a/app/helpers/refunds_helper.rb
+++ b/app/helpers/refunds_helper.rb
@@ -1,9 +1,15 @@
 module RefundsHelper
   def refund_officer_menu(selected)
+    # Get IDs for all users who have done at least one refund
     user_ids = Refund.pluck("DISTINCT user_id")
-    names = User.unscoped.include_player.where(id: user_ids).map { |user| user.player.name }
-    officers = names.zip(user_ids).sort { |a,b| a[0] <=> b[0] }
+
+    # Get all the users' names from the IDs
+    officers = User.unscoped.include_player.where(id: user_ids).map { |user| [user.player.name, user.id] }
+    officers.sort!
+
+    # Add 'Any Officer' option
     officers.unshift ["Any Officer", ""]
+    
     options_for_select(officers, selected)
   end
 end


### PR DESCRIPTION
Resolves #59.

The old code retrieved the correct user IDs and the names of the users but combined them incorrectly. They are now being paired up correctly.