### PR TITLE
Updated Gemfile.lock to remove bundler-audit and ruby_audit gems.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,9 +85,6 @@ GEM
     benchmark (0.5.0)
     bigdecimal (3.1.3)
     builder (3.2.4)
-    bundler-audit (0.9.3)
-      bundler (>= 1.2.0)
-      thor (~> 1.0)
     cancancan (3.4.0)
     capistrano (3.17.1)
       airbrussh (>= 1.0.0)
@@ -291,8 +288,6 @@ GEM
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
-    ruby_audit (3.1.0)
-      bundler-audit (~> 0.9.0)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -392,7 +387,6 @@ DEPENDENCIES
   redis
   rexml (>= 3.3.9)
   rspec-rails
-  ruby_audit
   sass-rails
   selenium-webdriver
   sprockets


### PR DESCRIPTION
Fixes Gemfile.lock file that had an extra gem which shouldn't have been there.