### PR TITLE
Pin version of base64 gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,12 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rails", "7.0.10"
+
+# Ruby 3.2 includes `base64` as a default gem (0.1.1). Under Passenger it may be
+# activated before Bundler loads, causing "already activated base64 0.1.1" errors
+# if the lockfile wants a newer base64.
+gem "base64", "0.1.1"
+
 gem "puma", ">= 6.4.3" # web server
 # gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '3543363026121ee28d98dfce4cb6366980c055ee' # Lastest version of mimemagic has copyright issues and breaks
 gem "sprockets" # Latest version of sprockets 2.*. 3.* causes a failure at startup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
-    base64 (0.3.0)
+    base64 (0.1.1)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
@@ -357,6 +357,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64 (= 0.1.1)
   bcrypt_pbkdf
   bigdecimal (>= 2.5.5)
   cancancan


### PR DESCRIPTION
so that it is compatible with Ruby 3.2 and Passenger.