### PR TITLE
Clear warnings from rspec run

### DIFF
--- a/spec/features/shop_spec.rb
+++ b/spec/features/shop_spec.rb
@@ -534,7 +534,7 @@ describe "Shop" do
 
     it "blocked by lack of subscription" do
       visit event_path(id: event.id)
-      click_link fee_requires_sub.amount
+      click_link fee_requires_sub.amount.to_s
       click_button select_member
       fill_in last_name, with: player.last_name + force_submit
       fill_in first_name, with: player.first_name + force_submit

--- a/spec/models/item/subscription_spec.rb
+++ b/spec/models/item/subscription_spec.rb
@@ -27,7 +27,7 @@ describe Item::Subscription do
     end
 
     it "normally a fee is required" do
-      expect{create(:nofee_subscription_item)}.to raise_error
+      expect{create(:nofee_subscription_item)}.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 


### PR DESCRIPTION
This PR aims to clear warnings collected from CI runs:

```
/usr/local/bundle/ruby/3.2.0/gems/capybara-3.38.0/lib/capybara/selector/selector.rb:69: warning: Locator BigDecimal:0.5e2 for selector :link must be an instance of String or Symbol. This will raise an error in a future version of Capybara. Called from: /rails/spec/features/shop_spec.rb:537
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<ActiveRecord::RecordInvalid: Validation failed: Fee can't be blank>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /rails/spec/models/item/subscription_spec.rb:30:in `block (3 levels) in <top (required)>'.
```