### PR TITLE
Allow Uglifier to compile ES6 scripts.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ IcuWwwApp::Application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This is needed to use Shane's new bit of javascript that does nice things on the event map.
That code is written in ES6, and Uglifier needs a flag to get it to understand ES6 syntax.