### PR TITLE
I added a deployment info page, only accessible to admins.

### DIFF
--- a/app/controllers/admin/deployment_info_controller.rb
+++ b/app/controllers/admin/deployment_info_controller.rb
@@ -1,0 +1,13 @@
+class Admin::DeploymentInfoController < ApplicationController
+  before_action :authorize_admin!
+
+  def show
+    @deployment_info = DeploymentInfo.current
+  end
+
+  private
+
+  def authorize_admin!
+    authorize! :show, DeploymentInfo
+  end
+end

--- a/app/models/deployment_info.rb
+++ b/app/models/deployment_info.rb
@@ -1,0 +1,84 @@
+class DeploymentInfo
+  DEPLOY_INFO_FILE = Rails.root.join("DEPLOY_INFO").freeze
+
+  attr_reader :deployed_at, :booted_at, :branch, :tag, :commit, :message
+
+  def self.current
+    new
+  end
+
+  def initialize
+    data = file_data.presence || git_data
+
+    @deployed_at = parse_time(data["deployed_at"])
+    @booted_at   = APP_BOOTED_AT
+    @branch      = presence(data["branch"])
+    @tag         = presence(data["tag"])
+    @commit      = presence(data["commit"])
+    @message     = presence(data["message"])
+  end
+
+  def uptime_in_words
+    return "unknown" unless booted_at
+
+    seconds = (Time.current - booted_at).to_i
+    parts = []
+
+    days = seconds / 86_400
+    seconds %= 86_400
+    hours = seconds / 3_600
+    seconds %= 3_600
+    minutes = seconds / 60
+    seconds %= 60
+
+    parts << "#{days}d" if days.positive?
+    parts << "#{hours}h" if hours.positive?
+    parts << "#{minutes}m" if minutes.positive?
+    parts << "#{seconds}s" if seconds.positive? || parts.empty?
+
+    parts.join(" ")
+  end
+
+  private
+
+  def file_data
+    return {} unless File.exist?(DEPLOY_INFO_FILE)
+
+    File.readlines(DEPLOY_INFO_FILE, chomp: true).each_with_object({}) do |line, memo|
+      key, value = line.split("=", 2)
+      next if key.blank? || value.blank?
+
+      memo[key.strip] = value.strip
+    end
+  rescue StandardError
+    {}
+  end
+
+  def git_data
+    {
+      "branch" => git("rev-parse", "--abbrev-ref", "HEAD"),
+      "tag"    => git("describe", "--tags", "--exact-match"),
+      "commit" => git("rev-parse", "HEAD"),
+      "message" => git("log", "-1", "--pretty=%s")
+    }
+  end
+
+  def git(*args)
+    output = IO.popen(["git", *args], err: File::NULL, &:read).to_s.strip
+    presence(output)
+  rescue StandardError
+    nil
+  end
+
+  def parse_time(value)
+    return nil if value.blank?
+
+    Time.zone.parse(value)
+  rescue StandardError
+    nil
+  end
+
+  def presence(value)
+    value.presence
+  end
+end

--- a/app/views/admin/deployment_info/show.html.haml
+++ b/app/views/admin/deployment_info/show.html.haml
@@ -1,0 +1,26 @@
+- content_for :title, t("deployment_info.title")
+
+%table.table.table-striped
+  %tbody
+    %tr
+      %th= t("deployment_info.deployed_at")
+      %td= @deployment_info.deployed_at ? l(@deployment_info.deployed_at, format: :long) : "Unknown"
+    %tr
+      %th= t("deployment_info.booted_at")
+      %td= @deployment_info.booted_at ? l(@deployment_info.booted_at, format: :long) : "Unknown"
+    %tr
+      %th= t("deployment_info.uptime")
+      %td= @deployment_info.uptime_in_words
+    %tr
+      %th= t("deployment_info.git_branch")
+      %td= @deployment_info.branch || "Unknown"
+    %tr
+      %th= t("deployment_info.git_tag")
+      %td= @deployment_info.tag || "Unknown"
+    %tr
+      %th= t("deployment_info.git_commit_hash")
+      %td
+        %code= @deployment_info.commit || "Unknown"
+    %tr
+      %th= t("deployment_info.git_message")
+      %td= @deployment_info.message || "Unknown"

--- a/app/views/layouts/_admin_menu.html.haml
+++ b/app/views/layouts/_admin_menu.html.haml
@@ -20,6 +20,7 @@
   - links += 1 if results    = can?(:manage, Result)
   - links += 1 if stats   = can?(:index, Admin::Statistic)
   - links += 1 if usage   = Rails.env.production? && current_user.admin?
+  - links += 1 if deploy_info = can?(:show, DeploymentInfo)
   - nfails = fails ? Failure.active.count : 0
   - if nfails > 0
     %li{class: active("admin/failures")}
@@ -78,3 +79,5 @@
           %li= link_to "Usage Stats", "/webalizer/", target: "_usage"
         - if users
           %li{class: active("admin/users")}= link_to "Users", admin_users_path
+        - if deploy_info
+          %li{class: active("admin/deployment_info")}= link_to "Deployment Info", admin_deployment_info_path

--- a/config/initializers/app_booted_at.rb
+++ b/config/initializers/app_booted_at.rb
@@ -1,0 +1,2 @@
+# config/initializers/app_booted_at.rb
+APP_BOOTED_AT = Time.current.freeze

--- a/config/locales/deployment_info/en.yml
+++ b/config/locales/deployment_info/en.yml
@@ -1,0 +1,10 @@
+en:
+  deployment_info:
+    title: "Deployment Info"
+    deployed_at: "Deployed at"
+    booted_at: "App booted at"
+    uptime: "App uptime"
+    git_branch: "Git branch"
+    git_tag: "Git tag"
+    git_commit_hash: "Git commit hash"
+    git_message: "Last commit message"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ IcuWwwApp::Application.routes.draw do
       get page => "pages##{page}"
     end
 
+    get "deployment_info" => "deployment_info#show"
+
     resources :articles,        only: [:new, :create, :edit, :update, :destroy]
     resources :article_ids,     only: [:index]
     resources :bad_logins,      only: [:index]

--- a/lib/capistrano/tasks/deploy_info.rake
+++ b/lib/capistrano/tasks/deploy_info.rake
@@ -1,0 +1,26 @@
+namespace :deploy do
+  desc "Write deploy metadata to DEPLOY_INFO in the release directory"
+  task :write_deploy_info do
+    on roles(:app) do
+      within release_path do
+        branch = fetch(:branch).to_s
+        commit = capture(:git, "rev-parse HEAD").strip
+        tag = capture(:git, "describe --tags --exact-match 2>/dev/null || true").strip
+        message = capture(:git, "log -1 --pretty=%s").strip
+        deployed_at = capture(:date, "-u +%Y-%m-%dT%H:%M:%SZ").strip
+
+        execute :bash, "-lc", <<~BASH
+          cat > #{release_path.join("DEPLOY_INFO")} <<'EOF'
+          deployed_at=#{deployed_at}
+          branch=#{branch}
+          tag=#{tag}
+          commit=#{commit}
+          message=#{message}
+          EOF
+        BASH
+      end
+    end
+  end
+end
+
+after "deploy:updating", "deploy:write_deploy_info"

--- a/spec/models/deployment_info_spec.rb
+++ b/spec/models/deployment_info_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe DeploymentInfo, type: :model do
+  describe ".current" do
+    it "loads branch, tag and commit from git when the deploy info file does not exist" do
+      allow(File).to receive(:exist?).with(described_class::DEPLOY_INFO_FILE).and_return(false)
+
+      allow(IO).to receive(:popen)
+                     .with(["git", "rev-parse", "--abbrev-ref", "HEAD"], err: File::NULL)
+                     .and_yield(double(read: "main\n"))
+
+      allow(IO).to receive(:popen)
+                     .with(["git", "describe", "--tags", "--exact-match"], err: File::NULL)
+                     .and_yield(double(read: "v1.2.3\n"))
+
+      allow(IO).to receive(:popen)
+                     .with(["git", "rev-parse", "HEAD"], err: File::NULL)
+                     .and_yield(double(read: "abcdef1234567890abcdef1234567890abcdef12\n"))
+
+      allow(IO).to receive(:popen)
+                     .with(["git", "log", "-1", "--pretty=%s"], err: File::NULL)
+                     .and_yield(double(read: "Add deployment info page\n"))
+
+      deployment_info = described_class.current
+
+      expect(deployment_info.deployed_at).to be_nil
+      expect(deployment_info.booted_at).to eq(APP_BOOTED_AT)
+      expect(deployment_info.branch).to eq("main")
+      expect(deployment_info.tag).to eq("v1.2.3")
+      expect(deployment_info.commit).to eq("abcdef1234567890abcdef1234567890abcdef12")
+      expect(deployment_info.message).to eq("Add deployment info page")
+    end
+
+    it "loads deployed_at, branch, tag and commit from the deploy info file when it exists" do
+      allow(File).to receive(:exist?).with(described_class::DEPLOY_INFO_FILE).and_return(true)
+      allow(File).to receive(:readlines).with(described_class::DEPLOY_INFO_FILE, chomp: true)
+                                        .and_return([
+                     "deployed_at=2026-03-08T12:34:56Z",
+                     "branch=main",
+                     "tag=v1.2.3",
+                     "commit=abcdef1234567890abcdef1234567890abcdef12",
+                     "message=Add deployment info page"
+                                                    ])
+
+      expect(IO).not_to receive(:popen)
+
+      deployment_info = described_class.current
+
+      expect(deployment_info.deployed_at).to eq(Time.zone.parse("2026-03-08T12:34:56Z"))
+      expect(deployment_info.booted_at).to eq(APP_BOOTED_AT)
+      expect(deployment_info.branch).to eq("main")
+      expect(deployment_info.tag).to eq("v1.2.3")
+      expect(deployment_info.commit).to eq("abcdef1234567890abcdef1234567890abcdef12")
+      expect(deployment_info.message).to eq("Add deployment info page")
+    end
+  end
+end


### PR DESCRIPTION
It shows various deployment metadata. It should be useful to see which git commit is running and when it was deployed.