### PR TITLE
Dual boot application (Rails 7.0 and 7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,17 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests (Rails ${{ matrix.rails_version }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rails_version: "7.0"
+            gemfile: "Gemfile"
+          - rails_version: "7.1"
+            gemfile: "Gemfile.next"
 
     steps:
       - name: Checkout code
@@ -26,8 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-buildx-${{ matrix.rails_version }}-${{ hashFiles('**/Gemfile.lock', '**/Gemfile.next.lock') }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.rails_version }}-
             ${{ runner.os }}-buildx-
 
       - name: Build Docker images
@@ -66,13 +76,17 @@ jobs:
             sleep 2
           done
 
+      - name: Install gems for target Rails version
+        run: |
+          docker compose exec -T -e BUNDLE_GEMFILE=${{ matrix.gemfile }} web bundle install
+
       - name: Create and prepare test database
         run: |
-          docker compose exec -T -e RAILS_ENV=test web bin/rails db:create db:test:prepare
+          docker compose exec -T -e RAILS_ENV=test -e BUNDLE_GEMFILE=${{ matrix.gemfile }} web bin/rails db:create db:test:prepare
 
       - name: Run RSpec tests
         run: |
-          docker compose exec -T -e RAILS_ENV=test web bundle exec rspec --format progress
+          docker compose exec -T -e RAILS_ENV=test -e BUNDLE_GEMFILE=${{ matrix.gemfile }} web bundle exec rspec --format progress
 
       - name: Show test logs on failure
         if: failure()
@@ -88,7 +102,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-screenshots
+          name: test-screenshots-rails-${{ matrix.rails_version }}
           path: tmp/screenshots/
           if-no-files-found: ignore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,18 @@ jobs:
 
       - name: Build Docker images
         run: |
-          docker compose build --build-arg BUILDKIT_INLINE_CACHE=1
+          docker compose build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BUNDLE_GEMFILE=${{ matrix.gemfile }}
         env:
           DOCKER_BUILDKIT: 1
           COMPOSE_DOCKER_CLI_BUILD: 1
+          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
       - name: Start services
         run: |
-          export SKIP_DB_SETUP=true
           docker compose up -d db redis web
+        env:
+          SKIP_DB_SETUP: "true"
+          BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
       - name: Wait for database to be ready
         run: |
@@ -75,10 +78,6 @@ jobs:
             echo "Waiting for Redis... ($i/30)"
             sleep 2
           done
-
-      - name: Install gems for target Rails version
-        run: |
-          docker compose exec -T -e BUNDLE_GEMFILE=${{ matrix.gemfile }} web bundle install
 
       - name: Create and prepare test database
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ ENV CHROME_BIN=/usr/bin/chromium \
 
 WORKDIR /rails
 
+ARG BUNDLE_GEMFILE=Gemfile
 ENV BUNDLE_PATH="/usr/local/bundle" \
-  BUNDLE_JOBS=4
+  BUNDLE_JOBS=4 \
+  BUNDLE_GEMFILE=${BUNDLE_GEMFILE}
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock Gemfile.next Gemfile.next.lock ./
 RUN bundle config build.sassc -- --with-cflags="-Wno-error"
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,18 @@
 source "https://rubygems.org"
 
+def next?
+  File.basename(__FILE__) == "Gemfile.next"
+end
+
 gem "rake"
-gem "rails", "7.0.10"
+
+if next?
+  gem "rails", "~> 7.1.0"
+else
+  gem "rails", "7.0.10"
+end
+
+gem "next_rails"
 
 # Ruby 3.2 includes `base64` as a default gem (0.1.1). Under Passenger it may be
 # activated before Bundler loads, causing "already activated base64 0.1.1" errors

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     netrc (0.11.0)
+    next_rails (1.4.7)
+      rainbow (>= 3)
     nio4r (2.5.8)
     nokogiri (1.19.0-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -269,6 +271,7 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
+    rainbow (3.1.1)
     rake (13.0.6)
     redcarpet (3.6.1)
     redis (5.0.5)
@@ -363,6 +366,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-24
+  arm64-darwin-25
   x64-mingw-ucrt
   x86_64-linux
 
@@ -395,6 +399,7 @@ DEPENDENCIES
   mailgun-ruby
   mini_racer
   mysql2
+  next_rails
   nokogiri (>= 1.18.9)
   puma (>= 6.4.3)
   rack (~> 2.2.20)
@@ -419,4 +424,4 @@ DEPENDENCIES
   wirble
 
 BUNDLED WITH
-   2.4.1
+   2.6.9

--- a/Gemfile.next
+++ b/Gemfile.next
@@ -1,0 +1,1 @@
+Gemfile

--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -1,0 +1,498 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.1.6)
+      actionpack (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activesupport (= 7.1.6)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.2)
+    actionpack (7.1.6)
+      actionview (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.6)
+      actionpack (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.1.6)
+      activesupport (= 7.1.6)
+      builder (~> 3.1)
+      cgi
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.6)
+      activesupport (= 7.1.6)
+      globalid (>= 0.3.6)
+    activemodel (7.1.6)
+      activesupport (= 7.1.6)
+    activerecord (7.1.6)
+      activemodel (= 7.1.6)
+      activesupport (= 7.1.6)
+      timeout (>= 0.4.0)
+    activestorage (7.1.6)
+      actionpack (= 7.1.6)
+      activejob (= 7.1.6)
+      activerecord (= 7.1.6)
+      activesupport (= 7.1.6)
+      marcel (~> 1.0)
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    airbrussh (1.6.1)
+      sshkit (>= 1.6.1, != 1.7.0)
+    base64 (0.1.1)
+    bcrypt_pbkdf (1.1.2)
+    bcrypt_pbkdf (1.1.2-arm64-darwin)
+    bcrypt_pbkdf (1.1.2-x86_64-darwin)
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
+    builder (3.3.0)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
+    cancancan (3.6.1)
+    capistrano (3.20.0)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (2.2.0)
+      capistrano (~> 3.1)
+    capistrano-maintenance (1.2.1)
+      capistrano (>= 3.0)
+    capistrano-rails (1.7.0)
+      capistrano (~> 3.1)
+      capistrano-bundler (>= 1.1, < 3)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    capybara-lockstep (2.3.1)
+      activesupport (>= 7.0)
+      capybara (>= 3.0)
+    caxlsx (4.4.1)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 2.4, < 4)
+    cgi (0.5.1)
+    childprocess (5.1.0)
+      logger (~> 1.5)
+    chronic (0.10.2)
+    climate_control (1.2.0)
+    colored (1.2)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    crass (1.0.6)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0)
+    database_cleaner-core (2.0.1)
+    date (3.5.1)
+    diff-lcs (1.6.2)
+    drb (2.2.3)
+    ed25519 (1.4.0)
+    erb (6.0.2)
+    erubi (1.13.1)
+    execjs (2.10.0)
+    factory_bot (6.5.6)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
+    faker (3.6.1)
+      i18n (>= 1.8.11, < 2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    flag_shih_tzu (0.3.23)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    haml (7.2.0)
+      temple (>= 0.8.2)
+      thor
+      tilt
+    haml-rails (3.0.0)
+      actionpack (>= 5.1)
+      activesupport (>= 5.1)
+      haml (>= 4.0.6)
+      railties (>= 5.1)
+    htmlentities (4.4.2)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    icu_name (1.3.0)
+    icu_utils (1.3.3)
+    io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jquery-rails (4.6.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    json (2.19.2)
+    kt-paperclip (7.3.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      marcel (~> 1.0.1)
+      mime-types
+      terrapin (>= 0.6.0, < 2.0)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    libv8-node (24.12.0.1)
+    libv8-node (24.12.0.1-aarch64-linux)
+    libv8-node (24.12.0.1-aarch64-linux-musl)
+    libv8-node (24.12.0.1-arm64-darwin)
+    libv8-node (24.12.0.1-x86_64-darwin)
+    libv8-node (24.12.0.1-x86_64-linux)
+    libv8-node (24.12.0.1-x86_64-linux-musl)
+    logger (1.7.0)
+    loofah (2.25.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    mailgun-ruby (1.4.2)
+      faraday (~> 2.1)
+      faraday-multipart (< 2)
+      mini_mime
+      zeitwerk
+    marcel (1.0.4)
+    matrix (0.4.3)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0317)
+    mini_mime (1.1.5)
+    mini_racer (0.20.0)
+      libv8-node (~> 24.12.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
+    mysql2 (0.5.7)
+      bigdecimal
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.3)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.1)
+    next_rails (1.4.7)
+      rainbow (>= 3)
+    nio4r (2.7.5)
+    nokogiri (1.19.2-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.2-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.2-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.2-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.2-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.2-x86_64-linux-musl)
+      racc (~> 1.4)
+    ostruct (0.6.3)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    public_suffix (7.0.5)
+    puma (7.2.0)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (2.2.22)
+    rack-session (1.0.2)
+      rack (< 3)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (1.0.1)
+      rack (< 3)
+      webrick
+    rails (7.1.6)
+      actioncable (= 7.1.6)
+      actionmailbox (= 7.1.6)
+      actionmailer (= 7.1.6)
+      actionpack (= 7.1.6)
+      actiontext (= 7.1.6)
+      actionview (= 7.1.6)
+      activejob (= 7.1.6)
+      activemodel (= 7.1.6)
+      activerecord (= 7.1.6)
+      activestorage (= 7.1.6)
+      activesupport (= 7.1.6)
+      bundler (>= 1.15.0)
+      railties (= 7.1.6)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.1.6)
+      actionpack (= 7.1.6)
+      activesupport (= 7.1.6)
+      cgi
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    redcarpet (3.6.1)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.28.0)
+      connection_pool
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (7.1.1)
+      actionpack (>= 7.0)
+      activesupport (>= 7.0)
+      railties (>= 7.0)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.7)
+    rubyzip (2.4.1)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
+    securerandom (0.4.1)
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
+    sprockets (4.2.2)
+      concurrent-ruby (~> 1.0)
+      logger
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      sprockets (>= 3.0.0)
+    sshkit (1.25.0)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    stringio (3.2.0)
+    stripe (18.4.2)
+    temple (0.10.4)
+    terrapin (1.1.1)
+      climate_control
+    terser (1.2.6)
+      execjs (>= 0.3.0, < 3)
+    thor (1.5.0)
+    tilt (2.7.0)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.1)
+      tzinfo (>= 1.0.0)
+    uri (1.1.1)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
+    webrick (1.9.2)
+    websocket (1.2.11)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    whenever (1.1.2)
+      chronic (>= 0.6.3)
+    wirble (0.1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+    zeitwerk (2.7.5)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  base64 (= 0.1.1)
+  bcrypt_pbkdf
+  bigdecimal (>= 2.5.5)
+  byebug
+  cancancan
+  capistrano
+  capistrano-maintenance (~> 1.2)
+  capistrano-rails
+  capistrano-rvm
+  capybara
+  capybara-lockstep
+  caxlsx
+  colored
+  database_cleaner
+  ed25519
+  factory_bot_rails
+  faker
+  flag_shih_tzu
+  haml-rails
+  icu_name (= 1.3.0)
+  icu_utils (= 1.3.3)
+  jquery-rails
+  kt-paperclip
+  launchy
+  mail (= 2.7.1)
+  mailgun-ruby
+  mini_racer
+  mysql2
+  next_rails
+  nokogiri (>= 1.18.9)
+  puma (>= 6.4.3)
+  rack (~> 2.2.20)
+  rails (~> 7.1.0)
+  rails-controller-testing
+  rake
+  redcarpet (= 3.6.1)
+  redis
+  rexml (>= 3.3.9)
+  rspec-rails
+  sass-rails
+  selenium-webdriver
+  sprockets
+  sprockets-rails
+  stripe
+  terrapin
+  terser (~> 1.2.6)
+  thor (>= 1.4.0)
+  tzinfo-data
+  webdrivers
+  whenever
+  wirble
+
+BUNDLED WITH
+   2.6.9

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,9 @@ module IcuWwwApp
     # Do not swallow errors in after_commit/after_rollback callbacks. (no longer a valid option)
     # config.active_record.raise_in_transactional_callbacks = true
 
-    # Removes deprecation warning
-    config.active_record.legacy_connection_handling = false
+    # Removes deprecation warning (removed in Rails 7.1)
+    unless NextRails.next?
+      config.active_record.legacy_connection_handling = false
+    end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,10 @@ services:
       retries: 5
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        BUNDLE_GEMFILE: ${BUNDLE_GEMFILE:-Gemfile}
     command: bundle exec rails server -b 0.0.0.0
     volumes:
       - .:/rails
@@ -42,6 +45,7 @@ services:
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: password
       REDIS_URL: redis://redis:6379/0
+      BUNDLE_GEMFILE: ${BUNDLE_GEMFILE:-Gemfile}
       SKIP_DB_SETUP: ${SKIP_DB_SETUP:-false}
     depends_on:
       db:


### PR DESCRIPTION
Hi there,

~This is a WIP PR to set up dual booting between Rails 7.0 and 7.1~

This is a PR to run the test suite with Rails 7.0 and 7.1.

It will: 

- Set up CI to run two jobs per Rails version
- Address legacy connection handling (for Rails 7.1) 

If the test suite with Rails 7.1 is passing, then it's a good sign that we can move on to QA Rails 7.1 in staging. 

Please check it out.

Thanks! 