### PR TITLE
ICUIU-9: Set config.secret_key_base from secrets.yml

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,8 +18,11 @@ module IcuWwwApp
 
     # Rails 7.2 removed Rails.application.secrets. This shim adds it back via config_for
     # so the rest of the codebase keeps working until a proper migration to credentials.
+    config.secrets = config_for(:secrets) # loads from config/secrets.yml
+    config.secret_key_base = config.secrets[:secret_key_base]
+
     def secrets
-      @_secrets ||= config_for(:secrets)
+      config.secrets
     end
 
     # Disable belongs_to required by default (introduced in 5.0 load_defaults).


### PR DESCRIPTION
This PR updates the monkeypatch that we used to be able to continue using the `secrets.yml` file to also set `config.secret_key_base`.

The previous code only set `config.secrets` but, while setting up the upat environment, we noticed that some Rails command require the `config.secret_key_base` value to be set too.