### PR TITLE
Fix missing verification emails.

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,7 +6,7 @@ class PasswordsController < ApplicationController
 
   # POST /password
   def create
-    user = User.for_subscribed_player(params[:email])
+    user = User.where(email: params[:email]).first
     unless user
       redirect_to new_password_path, notice: t('password.unknown_email')
       return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -301,21 +301,6 @@ class User < ApplicationRecord
     IcuMailer.forgot_password(id, token).deliver_now
   end
 
-  # Looks up a user with the given email. If no user is found, it looks for a player with the given email,
-  # who has a current subscription, and then creates a new user for that player.
-  # @return [User] if there is a player with the given email that is subscribed for the current season
-  def self.for_subscribed_player(email)
-    user = where(email: email).first
-    return user if user
-    season = Season.new
-    player = Player.subscribed_in(season).where(email: email).first
-    if player
-      User.create(email: email, player_id: player.id, expires_on: season.end, status: 'OK', password: "Reset#{rand(1_000_000_000)}")
-    else
-      nil
-    end
-  end
-
   private
 
   def canonicalize_roles

--- a/app/views/passwords/new.html.haml
+++ b/app/views/passwords/new.html.haml
@@ -4,11 +4,15 @@
   .col-sm-8.col-sm-offset-2
     %h1.text-center= t("password.new")
     %hr
+    %h4 Disclaimer
+    %p= t('password.disclaimer')
+    %p= link_to t("user.need_to_sign_up"), switch_to_tls(:sign_up)
+    %hr
     = form_tag password_path, method: :post, class: "form-horizontal", role: "form" do
       %fieldset
         - locals = { col: "sm", pad: 4, width: 4 }
         = render "utils/text_field_tag", locals.merge(param: :email, text: t("password.email"), type: 'email')
-        .text-sm= t('password.instructions')
+        %p= t('password.instructions')
       %hr
       .text-center
         = submit_tag t("send_request"), class: "btn btn-primary"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -10,10 +10,10 @@
       %fieldset
         - locals = { col: "sm", pad: 4, width: 4 }
         = render "utils/text_field_tag", locals.merge(param: :email, text: t("email"))
-      %p.small.text-center
-        = link_to t("user.need_to_sign_up"), switch_to_tls(:sign_up)
         = render "utils/text_field_tag", locals.merge(param: :password, text: t("user.password"), type: "password")
-      %p.small.text-center
+      %p.text-center
+        = link_to t("user.need_to_sign_up"), switch_to_tls(:sign_up)
+      %p.text-center
         = link_to t("user.forgot_password"), new_password_path
       %hr
       .text-center

--- a/config/locales/password/en.yml
+++ b/config/locales/password/en.yml
@@ -1,8 +1,9 @@
 en:
   send_request: Send request
   password:
+    disclaimer: If you are a member, but never set up an account, please create an account by clicking the link below.
     email: Email
     forgotten_password_email_sent: You have been sent an email with a link in it.
     new: "Forgot password?"
-    unknown_email: That email address is not known
-    instructions: "Enter your email address and click “Send Request”. You should receive an email from “no-reply@icu.ie” to that address containing a password reset link. Click on this link and complete the form by entering your new password twice and clicking Save. It takes upto 1 hour for your password change to filter across to the ratings site."
+    unknown_email: That email address is not associated with any user account.
+    instructions: "Enter your email address and click “Send Request”. You should receive an email from “no-reply@icu.ie” to that address containing a password reset link. Click on the link and complete the form by entering your new password twice and clicking Save. It takes up to 1 hour for your password change to filter across to the ratings site."

--- a/config/locales/user/en.yml
+++ b/config/locales/user/en.yml
@@ -15,7 +15,7 @@ en:
     incomplete_registration: Already created but waiting for response to verification message
     junior_newsletter: Would you like to receive a newsletter on junior chess by email?
     locale: Language
-    need_to_sign_up: Register if you have never had an account and are a member
+    need_to_sign_up: Click here to register if you have never had an account and are a member
     new: Register for website account
     new_password_1: New password
     new_password_2: Confirm password

--- a/spec/models/item/subscription_spec.rb
+++ b/spec/models/item/subscription_spec.rb
@@ -150,7 +150,7 @@ describe Item::Subscription do
     it "successful" do
       player = create(:player)
       create(:paid_subscription_item, player: player)
-      user = User.for_subscribed_player(player.email)
+      create(:user, player: player)
       expect{ Item::Subscription.new_lifetime_member(player.id) }.to_not raise_error
       for user in player.users
         expect(user.expires_on).to eq(Date.new(Date.today.year) + 100.years)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -179,32 +179,6 @@ describe User do
       expect(user.verification_param).to match /\A[a-f0-9]{10}\z/
     end
   end
-
-  context "#for_subscribed_player" do
-    it "should find existing user" do
-      existing_user = create(:user)
-      user = User.for_subscribed_player(existing_user.email)
-      expect(user).to eq(existing_user)
-    end
-
-    it "should not find user with no player" do
-      user = User.for_subscribed_player("no_email@no_email.com")
-      expect(user).to be nil
-    end
-
-    it "should not find user with unsubscribed player" do
-      player = create(:player)
-      user = User.for_subscribed_player(player.email)
-      expect(user).to be nil
-    end
-
-    it "should not find user with subscribed player" do
-      player = create(:player)
-      create(:paid_subscription_item, player: player)
-      user = User.for_subscribed_player(player.email)
-      expect(user).to_not be nil
-    end
-  end
 end
 
 describe User::Guest do


### PR DESCRIPTION
This should resolve #1.

Since automatically created users from the `for_subscribed_player` were not sent verification emails, this method was removed completely as this functionality is not needed. Instead, an extra link on the forgot password page was added to point members to the create user page. The font size on the login page for this link was increased as well to make it more obvious.