### PR TITLE
24 add club secretary id for a club

### DIFF
--- a/app/controllers/admin/clubs_controller.rb
+++ b/app/controllers/admin/clubs_controller.rb
@@ -34,6 +34,6 @@ class Admin::ClubsController < ApplicationController
   end
 
   def club_params
-    params[:club].permit(:name, :web, :meet, :address, :district, :city, :county, :eircode, :lat, :long, :contact, :email, :phone, :junior_only, :has_junior_section, :active)
+    params[:club].permit(:name, :web, :meet, :address, :district, :city, :county, :eircode, :lat, :long, :contact, :email, :phone, :junior_only, :has_junior_section, :active, :secretary_id)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,7 @@ class Ability
     can :index, [Article, Arbiter, Download, Game, Image, Series, Tournament]
     can :show, [Article, Arbiter, Game, Series, Tournament]
     can [:edit, :update], Arbiter, player_id: user.player_id
+    can [:edit, :update], Club, secretary_id: user.player_id if user.player_id.present?
 
     if user.admin?
       can :manage, :all

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -4,9 +4,10 @@ class Club < ApplicationRecord
   include Normalizable
   include Pageable
 
-  journalize %w[name web meet address district city county lat long contact email phone active], "/clubs/%d"
+  journalize %w[name web meet address district city county lat long contact email phone active secretary_id], "/clubs/%d"
 
   has_many :players
+  belongs_to :secretary, class_name: "Player", optional: true
 
   default_scope { order(:name) }
   scope :active, -> { where(active: true) }
@@ -29,6 +30,7 @@ class Club < ApplicationRecord
   validates :email, email: true, allow_nil: true
   validates :phone, format: { with: /\d{3}/ }, allow_nil: true
   validates :active, inclusion: { in: [true, false] }
+  validate :secretary_exists
 
   def province
     Ireland.province(county)
@@ -71,6 +73,12 @@ class Club < ApplicationRecord
   end
 
   private
+
+  def secretary_exists
+    if secretary_id.present? && !Player.exists?(secretary_id)
+      errors.add(:secretary_id, "player does not exist")
+    end
+  end
 
   def has_contact_method
     if active && !contactable?

--- a/app/views/admin/clubs/_form.html.haml
+++ b/app/views/admin/clubs/_form.html.haml
@@ -1,3 +1,8 @@
+- content_for :javascript do
+  = render(:partial => "player_ids_callback", :handlers => [:erb], :formats => [:js])
+
+= render "player_ids/modal", title: t("club.select_secretary")
+
 .row
   .col-sm-1
   .col-sm-10
@@ -18,6 +23,10 @@
         = render "utils/text_field_for", locals.merge(param: :contact, text: t("contact"))
         = render "utils/text_field_for", locals.merge(param: :email, text: t("email"))
         = render "utils/text_field_for", locals.merge(param: :phone, text: t("club.phone"))
+        = render "utils/text_field_for", locals.merge(param: :secretary_id, text: t("club.secretary"), width: 2)
+        .form-group
+          %div{class: "col-sm-offset-2 col-sm-4"}
+            = render "player_ids_button"
         = render "utils/check_box_for", locals.merge(param: :junior_only, text: t("club.junior_only"), width: 1)
         = render "utils/check_box_for", locals.merge(param: :has_junior_section, text: t("club.has_junior_section"), width: 1)
         = render "utils/check_box_for", locals.merge(param: :active, text: t("active"), width: 1)

--- a/app/views/admin/clubs/_player_ids_button.html.haml
+++ b/app/views/admin/clubs/_player_ids_button.html.haml
@@ -1,0 +1,1 @@
+%button{type: "button", class: "btn btn-info", "data-toggle" => "modal", "data-target" => "#player_ids_modal"}= t("club.select_secretary")

--- a/app/views/admin/clubs/_player_ids_callback.js.erb
+++ b/app/views/admin/clubs/_player_ids_callback.js.erb
@@ -1,0 +1,4 @@
+function player_ids_callback(icu_id, name) {
+  $('#club_secretary_id').val(icu_id);
+  $('#player_ids_modal').modal('hide');
+}

--- a/app/views/clubs/show.html.haml
+++ b/app/views/clubs/show.html.haml
@@ -52,6 +52,9 @@
         %th= t("club.phone")
         %td= @club.phone
       %tr
+        %th= t("club.secretary")
+        %td= @club.secretary.name if @club.secretary
+      %tr
         %th= t("club.junior_only")
         %td= t(@club.junior_only ? "yes" : "no")
       %tr

--- a/config/locales/club/en.yml
+++ b/config/locales/club/en.yml
@@ -20,4 +20,6 @@ en:
     meet: Meetings
     phone: Phone
     province: Province
+    secretary: Secretary
+    select_secretary: Select Secretary
     web: Website

--- a/db/migrate/20260706120000_add_secretary_id_to_clubs.rb
+++ b/db/migrate/20260706120000_add_secretary_id_to_clubs.rb
@@ -1,0 +1,6 @@
+class AddSecretaryIdToClubs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :clubs, :secretary_id, :integer
+    add_index :clubs, :secretary_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_16_120000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_06_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -152,10 +152,12 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_16_120000) do
     t.boolean "junior_only", default: false
     t.boolean "has_junior_section", default: false
     t.string "eircode"
+    t.integer "secretary_id"
     t.index ["active"], name: "index_clubs_on_active"
     t.index ["city"], name: "index_clubs_on_city"
     t.index ["county"], name: "index_clubs_on_county"
     t.index ["name"], name: "index_clubs_on_name"
+    t.index ["secretary_id"], name: "index_clubs_on_secretary_id"
   end
 
   create_table "documents", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/spec/features/admin/clubs_spec.rb
+++ b/spec/features/admin/clubs_spec.rb
@@ -136,6 +136,25 @@ describe Club do
       expect(page).to have_css(field_error, text: "invalid")
     end
 
+    it "secretary is saved and shown on the club page" do
+      player = create(:player)
+      fill_in I18n.t("club.secretary"), with: player.id
+      click_button save
+
+      expect(page).to have_css(success)
+      expect(@bangor.reload.secretary_id).to eq player.id
+
+      visit club_path(@bangor)
+      expect(page).to have_content(player.name)
+    end
+
+    it "secretary must be an existing player" do
+      fill_in I18n.t("club.secretary"), with: 999999
+      click_button save
+      expect(page).to have_css(field_error, text: "does not exist")
+      expect(@bangor.reload.secretary_id).to be_nil
+    end
+
     it "at least one contact method is mandadory for an active club" do
       fill_in website, with: ""
       fill_in email, with: ""

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -28,6 +28,31 @@ describe Ability do
 
   end
 
+  context "Club secretary" do
+    let(:secretary) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:club) { create(:club, secretary_id: secretary.player_id) }
+    let(:other_club) { create(:club, name: "Cork Chess Club") }
+
+    it "can edit and update their own club" do
+      ability = Ability.new(secretary)
+      expect(ability.can?(:edit, club)).to be true
+      expect(ability.can?(:update, club)).to be true
+    end
+
+    it "cannot edit or update other clubs" do
+      ability = Ability.new(secretary)
+      expect(ability.can?(:edit, other_club)).to be false
+      expect(ability.can?(:update, other_club)).to be false
+    end
+
+    it "other users cannot edit or update the club" do
+      ability = Ability.new(other_user)
+      expect(ability.can?(:edit, club)).to be false
+      expect(ability.can?(:update, club)).to be false
+    end
+  end
+
   context "Event permissions" do
     let(:creator) { create(:user, roles: "organiser") }
     let(:full_user) { create(:user, roles: "organiser") }

--- a/spec/models/club_spec.rb
+++ b/spec/models/club_spec.rb
@@ -3,6 +3,23 @@ require 'rails_helper'
 describe Club do
   let(:bangor) { create(:club) }
 
+  context "secretary" do
+    it "can be blank" do
+      bangor.secretary_id = nil
+      expect{ bangor.save! }.to_not raise_error
+    end
+
+    it "can be an existing player" do
+      bangor.secretary_id = create(:player).id
+      expect{ bangor.save! }.to_not raise_error
+    end
+
+    it "must reference an existing player" do
+      bangor.secretary_id = 999999
+      expect{ bangor.save! }.to raise_error(/does not exist/i)
+    end
+  end
+
   context "latitude and longitude" do
     it "can be blank" do
       bangor.lat = nil


### PR DESCRIPTION
Added a secretary_id to the Club model. The migration just adds a column, but does not link it as a foreign key to the players table. This is in line with all the other models which have a player id.

37Signals standard is to keep domain model stuff in the ruby code, and not in the database. For now, I'm sticking with that.

The edit page, has a player popup to help find the secretary.

I've also added plenty of specs.