### PR TITLE
URGENT: Fixed some users not being able to view events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -84,7 +84,7 @@ class EventsController < ApplicationController
     return unless Rails.env.production?
     return unless request.host == "icu.ie"
 
-    redirect_to "https://www.icu.ie#{request.fullpath}", status: :moved_permanently
+    redirect_to "https://www.icu.ie#{request.fullpath}", status: :moved_permanently, allow_other_host: true
   end
 
   def download_filename(event, section, extension)


### PR DESCRIPTION
The rails upgrade included an update to `redirect_to` which prevents redirects to another host, in this case from the non-www icu.ie to www.icu.ie. This one-line change allows that to happen in this specific case.