### PR TITLE
All metadata now comes from the server

### DIFF
--- a/lib/capistrano/tasks/deploy_info.rake
+++ b/lib/capistrano/tasks/deploy_info.rake
@@ -1,24 +1,22 @@
 namespace :deploy do
   desc "Write deploy metadata to DEPLOY_INFO in the release directory"
   task :write_deploy_info do
-    branch = `git rev-parse --abbrev-ref HEAD 2>/dev/null`.strip
-    tag = `git describe --tags --exact-match 2>/dev/null`.strip
-    message = `git log -1 --pretty=%s 2>/dev/null`.strip
     on roles(:app) do
-      within release_path do
-        commit = capture(:cat, "REVISION").strip
-        deployed_at = capture(:date, "-u +%Y-%m-%dT%H:%M:%SZ").strip
+      commit = capture(:cat, release_path.join("REVISION")).strip
+      branch = fetch(:branch).to_s
+      tag = capture(:git, "--git-dir", repo_path.to_s, "describe --tags --exact-match", commit, "2>/dev/null || true").strip
+      message = capture(:git, "--git-dir", repo_path.to_s, "log -1 --pretty=%s", commit).strip
+      deployed_at = capture(:date, "-u +%Y-%m-%dT%H:%M:%SZ").strip
 
-        execute :bash, "-lc", <<~BASH
-          cat > #{release_path.join("DEPLOY_INFO")} <<'EOF'
-          deployed_at=#{deployed_at}
-          branch=#{branch}
-          tag=#{tag}
-          commit=#{commit}
-          message=#{message}
-          EOF
-        BASH
-      end
+      info = <<~INFO
+        deployed_at=#{deployed_at}
+        branch=#{branch}
+        tag=#{tag}
+        commit=#{commit}
+        message=#{message}
+      INFO
+
+      upload! StringIO.new(info), release_path.join("DEPLOY_INFO").to_s
     end
   end
 end


### PR DESCRIPTION
Inside the on roles(:app) block — no more local backticks, so it no longer matters where or by whom cap is invoked.