### PR TITLE
Fixed mobile overflow-x styling issue on events/show page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -323,7 +323,7 @@ section .title-panel .subtitle {
 }
 
 section .show-panel .details {
-  margin: 15px 0 0 0;
+  margin: 15px 0;
   display: flex;
   flex-direction: column;
   gap: 8px 0;
@@ -634,6 +634,10 @@ section.entries .entries-list {
 @media (max-width: 768px) {
   .event-nav-sm {
     display: flex;
+  }
+
+  .container aside.side-content {
+    width: 100%;
   }
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
   end
 
   def home_page?
-    controller_name = "pages" && action_name == "home"
+    controller_name == "pages" && action_name == "home"
   end
 
   def flash_style(name)

--- a/app/views/admin/events/show.html.haml
+++ b/app/views/admin/events/show.html.haml
@@ -39,7 +39,7 @@
                     %li= link_to "SwissPerfect (csv)", csv_list_event_path(@event.id, section: section)
                     %li= link_to "FIDE pre-2013", swiss_manager_event_path(@event.id, section: section)
 
-      - if @entries.present?
+      - if @entries.present? && (@event.creator?(current_user) || current_user.admin?)
         = render "admin/events/changelog", entries: @entries
 
 - if @event.creator?(current_user) || current_user.admin?

--- a/spec/features/admin/series_spec.rb
+++ b/spec/features/admin/series_spec.rb
@@ -253,7 +253,7 @@ describe Series do
       fill_in article_title, with: episodes[0].article.title + force_submit
       click_link episodes[0].article.title
 
-      wait_a_second(0.5)
+      expect(page).to have_no_css(".modal-backdrop", wait: 5)
 
       click_button save
 
@@ -277,6 +277,7 @@ describe Series do
       click_link episodes[2].article.title
 
       expect(page).to have_css("#article_title_4", text: episodes[2].article.title)
+      expect(page).to have_no_css(".modal-backdrop", wait: 5)
 
       find(number(1, 3)).select("1")
       click_button save


### PR DESCRIPTION
Fixes an issue where on smaller mobile screens the entries rating data gets cut off

Before / After:

<img width="321" height="164" alt="image" src="https://github.com/user-attachments/assets/2ce44e82-a1a3-458a-a7c4-1cc52e554f9b" />
<img width="323" height="165" alt="image" src="https://github.com/user-attachments/assets/d6de6282-9fdb-472f-8c14-0dae0e983560" />