### PR TITLE
Fixed disabling JS in the stripe form

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -63,13 +63,31 @@ class Cart < ApplicationRecord
   def purchase(params, user)
     email = params[:confirmation_email]
     name = params[:payment_name]
-    intent = Stripe::PaymentIntent.retrieve(params[:payment_intent_id]) if params[:payment_intent_id]
+
+    begin
+      intent = Stripe::PaymentIntent.retrieve(params[:payment_intent_id]) if params[:payment_intent_id]
+    rescue Stripe::InvalidRequestError
+      # User disabled JS and submitted the form with a payment intent of an empty string.
+      add_payment_error({message: "Payment intent missing"}, name, email, "Something went wrong, please contact webmaster@icu.ie")
+      return
+    end
+      
+    # Verify intent integrity, preventing a user from using a payment intent of a different amount
+    if intent and intent.amount != cents(total_cost)
+      add_payment_error(intent, name, email, "Payment intent amount (#{intent.amount}) does not match cart amount (#{cents(total_cost)})")
+      return
+    end
+
     if intent and intent.status == 'succeeded'  
       latest_charge = intent.latest_charge
       Stripe::PaymentIntent.update(intent.id, {description: ["Cart #{id}", name, email].reject { |d| d.nil? }.join(", "),})
       successful_payment("stripe", intent.id, latest_charge, Cart.current_payment_account)
     elsif intent and not intent.status == 'succeeded'
       add_payment_error(intent, name, email, "Something went wrong, please contact webmaster@icu.ie")
+      return
+    elsif total_cost > 0.0
+      # Catches the rare cases where the user disables JS and deletes the payment intent from the form before submitting
+      add_payment_error({message: "Payment intent missing"}, name, email, "Something went wrong, please contact webmaster@icu.ie")
       return
     else
       successful_payment("free", nil, nil, Cart.current_payment_account)

--- a/app/views/payments/_card.js.erb
+++ b/app/views/payments/_card.js.erb
@@ -1,5 +1,9 @@
 const stripe = Stripe('<%= Rails.application.secrets.stripe[:public] %>');
 $(function() {
+
+  $('#javascript-message').hide();
+  $('#submit-btn').prop('disabled', false);
+
   const options = {
     clientSecret: "<%= @intent.client_secret %>"
   };

--- a/app/views/payments/card.html.haml
+++ b/app/views/payments/card.html.haml
@@ -16,6 +16,13 @@
       %button.close{"type" => "button", "data-dismiss" => "alert"} ×
       %span{id: "payment_error_message"}
 
+#javascript-message
+  .col-sm-12
+    .text-center{class: "alert alert-danger"}
+      %button.close{"type" => "button", "data-dismiss" => "alert"} ×
+      %span
+        Please enable JavaScript in your browser to complete the payment process.
+
 = form_tag charge_path(format: "js"), id: "stripe_form", class: "form-horizontal", role: "form", :data => {:secret => @intent.client_secret} do
   - locals = { col: "sm", pad: 5, width: 3, param: nil}
   .row
@@ -37,7 +44,7 @@
   .row
     .col-sm-5
     .col-sm-7
-      = button_tag t("shop.payment.card.pay"), type: "submit", class: "btn btn-success btn-md", id: "submit-btn"
+      = button_tag t("shop.payment.card.pay"), type: "submit", class: "btn btn-success btn-md", id: "submit-btn", disabled: true
       = link_to t("cancel"), cart_path, class: "btn btn-info btn-md", id: "cancel_button"
   %hr
   .row


### PR DESCRIPTION
To resolve #188. I also added an alert at the top of the form to instruct users to enable JS.