### PR TITLE
Added a spotlight feature for Irish Championship 2026 to homepage

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require bootstrap.min
 //= require openmaps
+//= require spotlight
 
 // Auto-submit on change.
 $(function() {

--- a/app/assets/javascripts/spotlight.js
+++ b/app/assets/javascripts/spotlight.js
@@ -1,0 +1,47 @@
+$(function() {
+  var $countdown = $(".spotlight .countdown[data-spotlight-start]");
+  if (!$countdown.length) return;
+
+  var startAt = new Date($countdown.attr("data-spotlight-start")).getTime();
+  if (isNaN(startAt)) return;
+
+  var $actions = $(".spotlight .actions.pending");
+  var $units = $countdown.find(".units");
+
+  function makeGroup(label, width) {
+    var $group = $("<div>", { "class": "group" }).appendTo($units);
+    var $digits = $("<div>", { "class": "digits" }).appendTo($group);
+    var boxes = [];
+    for (var i = 0; i < width; i++) {
+      boxes.push($("<span>", { "class": "digit" }).appendTo($digits));
+    }
+    $("<span>", { "class": "name", text: label }).appendTo($group);
+    return boxes;
+  }
+
+  function setValue(boxes, value) {
+    var str = String(value);
+    while (str.length < boxes.length) str = "0" + str;
+    $.each(boxes, function(i, box) { box.text(str.charAt(i)); });
+  }
+
+  var totalHours = Math.floor((startAt - Date.now()) / 3600000);
+  var hours = makeGroup("Hrs", Math.max(2, String(totalHours).length));
+  $("<span>", { "class": "sep", text: ":" }).appendTo($units);
+  var mins = makeGroup("Mins", 2);
+
+  function tick() {
+    var diff = startAt - Date.now();
+    if (diff <= 0) {
+      $countdown.hide();
+      $actions.removeClass("pending");
+      return;
+    }
+    var s = Math.floor(diff / 1000);
+    setValue(hours, Math.floor(s / 3600));
+    setValue(mins, Math.floor((s % 3600) / 60));
+    setTimeout(tick, 1000);
+  }
+
+  tick();
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -702,7 +702,7 @@ section.spotlight::before {
   z-index: 1;
   inset: 0;
   content: "";
-  background: linear-gradient(160deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, rgb(from var(--brand-info-darker) r g b / 0.95) 60%, rgb(from var(--brand-info-darker) r g b / 0.5) 85%, transparent 100%),
+  background: linear-gradient(160deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, color-mix(in oklab, var(--brand-info-darker), transparent 5%) 60%, color-mix(in oklab, var(--brand-info-darker), transparent 50%) 85%, transparent 100%),
     url("data:image/svg+xml,%3Csvg width='16' height='20' viewBox='0 0 16 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f9bb73' fill-opacity='0.18' fill-rule='evenodd'%3E%3Cpath d='M8 0v20L0 10M16 0v10L8 0M16 10v10H8'/%3E%3C/g%3E%3C/svg%3E");
 }
 
@@ -852,7 +852,7 @@ section.spotlight .links ul {
 /* Bootstrap SM Breakpoint */
 @media (max-width: 768px) {
   section.spotlight::before {
-    background: linear-gradient(130deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, rgb(from var(--brand-info-darker) r g b / 0.95) 60%, rgb(from var(--brand-info-darker) r g b / 0.5) 85%, transparent 100%),
+    background: linear-gradient(130deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, color-mix(in oklab, var(--brand-info-darker), transparent 5%) 60%, color-mix(in oklab, var(--brand-info-darker), transparent 50%) 85%, transparent 100%),
       url("data:image/svg+xml,%3Csvg width='16' height='20' viewBox='0 0 16 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f9bb73' fill-opacity='0.18' fill-rule='evenodd'%3E%3Cpath d='M8 0v20L0 10M16 0v10L8 0M16 10v10H8'/%3E%3C/g%3E%3C/svg%3E");
   }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -687,6 +687,202 @@ section.stats-panel .list-col {
   padding: 1.5em
 }
 
+/* -- HOME -- */
+
+section.spotlight {
+  position: relative;
+  color: white;
+  background: var(--brand-info-darker);
+  padding: 21px 15px;
+  margin: 0 0 21px 0;
+}
+
+section.spotlight::before {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  content: "";
+  background: linear-gradient(160deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, rgb(from var(--brand-info-darker) r g b / 0.95) 60%, rgb(from var(--brand-info-darker) r g b / 0.5) 85%, transparent 100%),
+    url("data:image/svg+xml,%3Csvg width='16' height='20' viewBox='0 0 16 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f9bb73' fill-opacity='0.18' fill-rule='evenodd'%3E%3Cpath d='M8 0v20L0 10M16 0v10L8 0M16 10v10H8'/%3E%3C/g%3E%3C/svg%3E");
+}
+
+section.spotlight .wrap {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  align-items: flex-start;
+  gap: 30px;
+}
+
+section.spotlight .main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+section.spotlight header {
+  font-size: 2em;
+  line-height: 1.25em;
+  letter-spacing: 0.025em;
+  margin: 0 0 21px 0;
+}
+
+section.spotlight header .eyebrow {
+  color: var(--gray-lighter);
+  font-size: 13px;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+section.spotlight header .eyebrow > .highlight {
+  color: var(--brand-warning-light);
+}
+
+section.spotlight .actions {
+  display: flex;
+  align-items: center;
+  gap: 0 5px;
+}
+
+section.spotlight .actions .btn-lichess {
+  color: var(--brand-info-darker);
+  background: var(--brand-warning-light);
+  border-color: var(--brand-warning-light);
+}
+
+section.spotlight .actions .btn-stream {
+  display: none;
+  color: var(--body-bg);
+  background: var(--brand-info-dark);
+  border-color: var(--brand-info-dark);
+}
+
+section.spotlight .pending {
+  display: none;
+}
+
+section.spotlight .units {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+section.spotlight .digits {
+  display: flex;
+  gap: 4px;
+}
+
+section.spotlight .digit {
+  min-width: 24px;
+  padding: 6px;
+  font-size: 1.25em;
+  line-height: 1.25;
+  text-align: center;
+  background: var(--brand-primary);
+  border-radius: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+section.spotlight .sep {
+  padding: 6px 0;
+  font-size: 1.25em;
+  line-height: 1.25;
+}
+
+section.spotlight .name {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8em;
+  font-weight: 300;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+section.spotlight .side {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+}
+
+section.spotlight .commentary {
+  min-width: 0;
+}
+
+section.spotlight .heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 0 8px 0;
+  font-weight: 400;
+}
+
+section.spotlight .heading a {
+  font-size: 0.875em;
+  color: var(--brand-info-light);
+  text-decoration: underline;
+}
+
+section.spotlight .box {
+  aspect-ratio: 16 / 9;
+  height: 180px;
+  border: 1px solid var(--brand-warning-light);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+section.spotlight .box iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+section.spotlight .links {
+  flex: 0 0 120px;
+}
+
+section.spotlight .links ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+/* Bootstrap SM Breakpoint */
+@media (max-width: 768px) {
+  section.spotlight::before {
+    background: linear-gradient(130deg, var(--brand-info-darker) 0%, var(--brand-info-darker) 45%, rgb(from var(--brand-info-darker) r g b / 0.95) 60%, rgb(from var(--brand-info-darker) r g b / 0.5) 85%, transparent 100%),
+      url("data:image/svg+xml,%3Csvg width='16' height='20' viewBox='0 0 16 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23f9bb73' fill-opacity='0.18' fill-rule='evenodd'%3E%3Cpath d='M8 0v20L0 10M16 0v10L8 0M16 10v10H8'/%3E%3C/g%3E%3C/svg%3E");
+  }
+
+  section.spotlight header {
+    font-size: 1.75em;
+    margin: 0 0 15px 0;
+  }
+
+  section.spotlight .side {
+    display: none;
+  }
+
+  section.spotlight .actions {
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+
+  section.spotlight .actions .btn {
+    padding: 6px 9px;
+    font-size: 13px;
+    line-height: 1.5;
+    border-radius: 3px;
+  }
+
+  section.spotlight .actions .btn-stream {
+    display: inline-block;
+  }
+}
+
+
 /* Homepage Links */
 .home-page-links>.mobile-links {
   display: none;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@ class PagesController < ApplicationController
   before_action :load_donate_fee, except: :not_found
 
   def home
+    @spotlight = Spotlight.current
     @news = News.active.nonjunior.ordered.limit(8)
     @ongoing_events = Event.active.short.where(category: %w(irish women)).where('start_date <= ? AND end_date >= ?', Date.today, Date.today).ordered.limit(4)
     @upcoming_events = Event.active.short.where(category: %w(irish women)).where('start_date > ?', Date.today).ordered.limit(4)

--- a/app/models/spotlight.rb
+++ b/app/models/spotlight.rb
@@ -1,0 +1,88 @@
+class Spotlight
+  EVENT_ID = 2155
+
+  TITLE_LINES = ["Irish Chess", "Championship", "2026"].freeze
+  EYEBROW_HIGHLIGHT = "105th Edition"
+
+  attr_reader :event
+
+  delegate :start_date, :end_date, to: :event
+
+  def self.current
+    event = Event.active.find_by(id: EVENT_ID)
+    new(event) if event && Date.current <= event.end_date
+  end
+
+  def initialize(event)
+    @event = event
+  end
+
+  def title
+    TITLE_LINES.join(" ")
+  end
+
+  def title_lines
+    TITLE_LINES
+  end
+
+  def eyebrow_dates
+    if start_date.year == end_date.year && start_date.month == end_date.month
+      "#{start_date.mday}–#{end_date.mday} #{start_date.strftime('%B')}"
+    else
+      event.dates
+    end
+  end
+
+  def starts_at
+    @starts_at ||= start_date.in_time_zone.change(hour: 12)
+  end
+
+  def started?
+    Time.current >= starts_at
+  end
+
+  def lichess_url
+    event.live_games_url2.presence
+  end
+
+  def stream_url
+    event.streaming_url.presence
+  end
+
+  def pairings_url
+    event.pairings_url.presence
+  end
+
+  def results_url
+    event.results_url.presence
+  end
+
+  def stream_label
+    return unless stream_uri
+    return "Twitch.tv" if stream_uri.host.to_s.match?(/twitch\.tv/)
+    return "YouTube"   if stream_uri.host.to_s.match?(/youtube\.com|youtu\.be/)
+  end
+
+  def youtube_video_id
+    return unless stream_uri
+    case stream_uri.host
+    when /youtube\.com/ then CGI.parse(stream_uri.query.to_s)["v"]&.first
+    when /youtu\.be/    then stream_uri.path.split("/")[1]
+    end
+  end
+
+  def twitch_channel_id
+    return unless stream_uri
+    stream_uri.path.split("/")[1] if stream_uri.host.to_s.match?(/twitch\.tv/)
+  end
+
+  def stream_embed?
+    youtube_video_id.present? || twitch_channel_id.present?
+  end
+
+  private
+
+  def stream_uri
+    stream_url ? (URI.parse(stream_url) rescue nil) : nil
+  end
+end

--- a/app/views/pages/_spotlight.html.haml
+++ b/app/views/pages/_spotlight.html.haml
@@ -1,0 +1,46 @@
+%section{class: "spotlight full-width", "aria-label": "Spotlight: #{@spotlight.title}"}
+  .container
+    .wrap
+      .main
+        %header
+          .eyebrow
+            %span.highlight= Spotlight::EYEBROW_HIGHLIGHT
+            = " | #{@spotlight.eyebrow_dates}"
+          - @spotlight.title_lines.each_with_index do |line, i|
+            = line
+            - unless i == @spotlight.title_lines.size - 1
+              %br
+        - unless @spotlight.started?
+          .countdown{"data-spotlight-start" => @spotlight.starts_at.iso8601}
+            .units
+        .actions{class: ("pending" unless @spotlight.started?)}
+          - if @spotlight.lichess_url
+            %a.btn.btn-lichess{href: @spotlight.lichess_url, target: "event"}
+              Watch live on Lichess
+          - if @spotlight.stream_url
+            %a.btn.btn-stream{href: @spotlight.stream_url, target: "event"}
+              = @spotlight.stream_label ? "Live Commentary | #{@spotlight.stream_label}" : "Watch the live stream"
+      .side
+        - if @spotlight.stream_url
+          .commentary
+            .heading
+              = t("event.streaming_embed")
+              - if @spotlight.stream_label
+                = link_to @spotlight.stream_label, @spotlight.stream_url, target: "event"
+            .box
+              - if @spotlight.youtube_video_id
+                %iframe{src: "https://www.youtube-nocookie.com/embed/#{@spotlight.youtube_video_id}?controls=0",
+                        title: "YouTube video player", frameborder: "0",
+                        allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+                        referrerpolicy: "strict-origin-when-cross-origin", allowfullscreen: true}
+              - elsif @spotlight.twitch_channel_id
+                %iframe{src: "https://player.twitch.tv/?channel=#{@spotlight.twitch_channel_id}&parent=icu.ie&parent=www.icu.ie&autoplay=false",
+                        title: "Twitch.tv video player", allowfullscreen: true}
+        .links
+          .heading Links
+          %ul
+            - if @spotlight.results_url
+              %li= link_to "Standings", @spotlight.results_url, target: "event", class: "btn btn-primary btn-block"
+            - if @spotlight.pairings_url
+              %li= link_to "Pairings", @spotlight.pairings_url, target: "event", class: "btn btn-primary btn-block"
+            %li= link_to "Event Page", event_path(@spotlight.event), class: "btn btn-primary btn-block"

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -1,13 +1,19 @@
--# .row.results
--#   = render 'results'
-.row
-  .col-sm-3
-    = render "home_page_links"
-    = render 'irish'
-  .col-sm-7
-    = render 'news'
-  .col-sm-2
-    = render 'layouts/features'
-.row
-  .col-sm-12
-    = render 'layouts/sponsors'
+- @show_main_container = "false"
+
+-# Temporary hardcoded spotlight for Irish Championships 2026
+- if @spotlight
+  - content_for :header_bg_color, "linear-gradient(180deg, var(--gray-lighter) 50%, var(--brand-info-darker) 50%)"
+  = render "pages/spotlight"
+
+.container
+  .row
+    .col-sm-3
+      = render "home_page_links"
+      = render 'irish'
+    .col-sm-7
+      = render 'news'
+    .col-sm-2
+      = render 'layouts/features'
+  .row
+    .col-sm-12
+      = render 'layouts/sponsors'

--- a/spec/models/spotlight_spec.rb
+++ b/spec/models/spotlight_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe Spotlight do
+  let(:event) { create(:event) }
+  let(:spotlight) { described_class.new(event) }
+
+  before { stub_const("Spotlight::EVENT_ID", event.id) }
+
+  describe ".current" do
+    it "returns a spotlight for the configured event, nil if it doesn't exist" do
+      expect(described_class.current.event).to eq(event)
+      stub_const("Spotlight::EVENT_ID", 0)
+      expect(described_class.current).to be_nil
+    end
+  end
+
+  describe "#lichess_url" do
+    it "reads live_games_url2, nil when blank" do
+      expect(spotlight.lichess_url).to be_nil
+      event.update!(live_games_url2: "https://lichess.org/broadcast/x")
+      expect(spotlight.lichess_url).to eq("https://lichess.org/broadcast/x")
+    end
+  end
+
+  describe "stream parsing" do
+    it "parses twitch and youtube urls" do
+      event.update!(streaming_url: "https://www.twitch.tv/irishchess")
+      expect(spotlight.stream_label).to eq("Twitch.tv")
+      expect(spotlight.twitch_channel_id).to eq("irishchess")
+
+      event.update!(streaming_url: "https://www.youtube.com/watch?v=abc123")
+      expect(spotlight.stream_label).to eq("YouTube")
+      expect(spotlight.youtube_video_id).to eq("abc123")
+    end
+  end
+end


### PR DESCRIPTION
Resolves #193 

Added a basic spotlight feature to the top of the homepage that will prominently link out to the main championship's links, live boards, live commentary. Or if the event's not started yet it shows a basic countdown.

Just because sometimes you don't know as a casual website visitor that the top events of the yearly calendar are even on at that moment.

----

To test just swap the EVENT const in spotlight.rb model to an event ID you have seeded locally.

I'll come back later and flesh it out with an admin page and DB table to allow executive members to toggle it on/off and customise the data for the top ICU events. ICC, womens, juniors, seniors, rapid & blitz etc.

Desktop preview (_if there's a commentary url_):
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/f3fc31ac-c761-4863-b449-0d3fb9acd8b6" />

Mobile preview:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/9d258968-7f40-4c24-aea1-3f030a28ae7d" />

