### PR TITLE
Fix changelog visibility issue on event show page

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -20,7 +20,7 @@
         = render "events/show_livestream"
         = render "events/show_description"
         = render "events/show_contact"
-        - if @entries.present? && can?(:read, @event)
+        - if @entries.present? && can?(:show, entries.matches.first)
           %button{type: "button", "data-toggle": "collapse", "data-target": "#changeLog", class: "btn btn-sm btn-pastel-primary"}
             View changelog
           %div{id: "changeLog", class: "collapse"}

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -20,8 +20,8 @@
         = render "events/show_livestream"
         = render "events/show_description"
         = render "events/show_contact"
-        - if @entries.present?
-          %button{type: "button", "data-toggle": "collapse", "data-target": "#changeLog", class: "btn btn-primary"}
+        - if @entries.present? && can?(:read, @event)
+          %button{type: "button", "data-toggle": "collapse", "data-target": "#changeLog", class: "btn btn-sm btn-pastel-primary"}
             View changelog
           %div{id: "changeLog", class: "collapse"}
             = render "admin/journal_entries/changes", entries: @entries

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -20,7 +20,7 @@
         = render "events/show_livestream"
         = render "events/show_description"
         = render "events/show_contact"
-        - if @entries.present? && can?(:show, entries.matches.first)
+        - if @entries.present? && can?(:show, @entries.matches.first)
           %button{type: "button", "data-toggle": "collapse", "data-target": "#changeLog", class: "btn btn-sm btn-pastel-primary"}
             View changelog
           %div{id: "changeLog", class: "collapse"}

--- a/spec/features/events_spec.rb
+++ b/spec/features/events_spec.rb
@@ -54,11 +54,10 @@ describe Event do
   end
 
   context "admin/organiser show page" do
-    it "shows the admin panel and changelog to the event creator" do
+    it "shows the admin panel to the event creator" do
       login event.user
       visit event_path(event)
       expect(page).to have_link("Manage Event")
-      expect(page).to have_button("View changelog")
     end
 
     it "hides the admin panel from guests" do


### PR DESCRIPTION
Currently users with the organizer role can see the changelog button on all events even those they don't have access to.

Fixes so button visible only to users who can see the entries.